### PR TITLE
Updating docs and configs for latest patched version of FSF

### DIFF
--- a/docs/guide/README.adoc
+++ b/docs/guide/README.adoc
@@ -210,6 +210,18 @@ http://IPADDRESS - Kibana
 === Full Packet Capture
 Google's Stenographer is installed and configured in this build. However, it is disabled by default. There are a few reasons for this: First, it can be too much for Vagrant builds on meager hardware. Second, you really need to make sure you've mounted /data over sufficient storage before you start saving full packets. Once you're ready to get nuts, enable and start the service with `systemctl enable stenographer.service` and then `systemctl start stenographer.service`. Stenographer is already stubbed into the `/usr/local/bin/rock_{start,stop,status}` scripts, you just need to uncomment it if you're going to use it.
 
+=== File Scanning Framework
+Emerson Electric Co's File Scanning Framework is installed and configured in this build to analyze files seen by bro that are of specific mime-types, however this service is disabled by default. There are two primary reasons for this: First, just like stenographer FSF can be too much for ROCK builds on meager hardware. Second, you should carefully consider what file types you want to extract and what additional yara rules you want to scan your extracted files with. If you choose to Enable FSF in /etc/rocknsm/config.yml, the default configuration will automatically scan any of the following file types seen by bro and log the results to Elasticsearch.
+ - application/pdf
+ - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+ - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+ - application/vnd.openxmlformats-officedocument.presentationml.presentation
+ - application/x-dosexec
+ - application/java-archive
+ - application/x-java-applet
+ - application/x-java-jnlp-file
+
+
 == THANKS
 This architecture is made possible by the efforts of the Missouri National Guard Cyber Team for donating talent and resources to further development.
 

--- a/docs/guide/configuration.adoc
+++ b/docs/guide/configuration.adoc
@@ -98,6 +98,10 @@ Generally, most of the options you'll want to change are near the top. The file 
 
 *NOTE*: While you theoretically _could_ install both Suricata and Snort, I guarantee that the automated deployment will not configure this as you were hoping.
 
+| with_fsf
+| `True`
+| Determines whether FSF will be installed and configured.
+
 | with_snort
 | `False`
 | Determines whether Snort will be installed and configured.

--- a/playbooks/deploy-rock.yml
+++ b/playbooks/deploy-rock.yml
@@ -650,6 +650,13 @@
       state: present
     when: with_bro and with_kafka
 
+  - name: Enable the SMB Analyzer in local.bro
+    lineinfile:
+      dest: /opt/bro/share/bro/site/local.bro
+      line: "@load policy/protocols/smb # Enable Bro SMB Analyzer"
+      state: present
+    when: with_bro
+
   - name: Add bro to path and aliases
     copy:
       src: profile.d-bro.sh

--- a/playbooks/files/logstash-fsf-es.conf
+++ b/playbooks/files/logstash-fsf-es.conf
@@ -1,7 +1,7 @@
 input {
   file {
     codec => "json"
-    path => "/data/fsf/scan.log"
+    path => "/data/fsf/rockout.log"
     add_field => { "[@metadata][stage]" => "fsf" }
   }
 }

--- a/playbooks/templates/fsf-server-config.j2
+++ b/playbooks/templates/fsf-server-config.j2
@@ -9,7 +9,8 @@ SCANNER_CONFIG = { 'LOG_PATH' : '{{ fsf_data_dir }}',
                    'EXPORT_PATH' : '{{ fsf_archive_dir }}',
                    'TIMEOUT' : 60,
                    'PID_PATH': '/run/fsf/fsf.pid',
-                   'MAX_DEPTH' : 10 }
+                   'MAX_DEPTH' : 10,
+		   'ACTIVE_LOGGING_MODULES': ['rockout', 'scan_log'] }
 
 SERVER_CONFIG = { 'IP_ADDRESS' : "localhost",
                   'PORT' : 5800 }


### PR DESCRIPTION
* Add the modular logging configuration values to fsf-server.conf.config.scanner_config
* Since FSF is disabled by default like Stenographer, added a short description of why we did that, and what happens if you enable FSF to the guide's README to keep things consistent
* Updated ROCK configuration to include fsf