### PR TITLE
Update stenographer-config.j2 and stenoread

### DIFF
--- a/playbooks/files/stenoread
+++ b/playbooks/files/stenoread
@@ -74,7 +74,7 @@ echo "Running stenographer query '$STENOQUERY', piping to 'tcpdump $@'" >&2
 
 for IFACE in ${INTERFACES[@]}
 do
-  STENOGRAPHER_CONFIG="${STENOGRAPHER_CONFIG_BASE}${IFACE}"
+  export STENOGRAPHER_CONFIG="${STENOGRAPHER_CONFIG_BASE}${IFACE}"
   "$STENOCURL" /query \
     -d "$STENOQUERY" \
     --silent \

--- a/playbooks/templates/stenographer-config.j2
+++ b/playbooks/templates/stenographer-config.j2
@@ -3,6 +3,8 @@
     {
       "PacketsDirectory": "/data/stenographer/{{ item.1 }}/thread0/packets"
     , "IndexDirectory": "/data/stenographer/{{ item.1 }}/thread0/index"
+    , "MaxDirectoryFiles": 30000
+    , "DiskFreePercentage": 10
     }
   ]
   , "StenotypePath": "/usr/bin/stenotype"


### PR DESCRIPTION
Adding in the default configurations into the stenographer's configuration file will enhance the self-documentation of the tool. This will make it easier to understand the behaviors of the tool without referencing the GitHub document.
The default values were obtained from:
https://github.com/google/stenographer/blob/master/INSTALL.md

To quote the the INSTALL.md document:

"MaxDirectoryFiles: The maximum number of packet/index files to create before cleaning old ones up. Defaults to 30K files..."
"Note that DiskFreePercentage is optional... it defaults to 10%."