### PR TITLE
Fixing paths for #115

### DIFF
--- a/playbooks/deploy-rock.yml
+++ b/playbooks/deploy-rock.yml
@@ -1159,6 +1159,17 @@
       owner: root
       group: root
 
+  - name: Create rock script symlinks
+    file:
+      src: "/usr/local/bin/{{ item.src }}"
+      dest: "/usr/sbin/{{ item.dest }}"
+      force: yes
+      state: link
+    with_items:
+      - { src: 'rock_start', dest: 'rock_start' }
+      - { src: 'rock_stop', dest: 'rock_stop' }
+      - { src: 'rock_status', dest: 'rock_status' }
+
   # Training mode / Service mode not needed for AF_PACKET
   ######################################################
   ############### ROCKNSM Customization ################

--- a/playbooks/files/profile.d-bro.sh
+++ b/playbooks/files/profile.d-bro.sh
@@ -1,6 +1,3 @@
-# Load bro to PATH
-pathmunge /opt/bro/bin
-
 # Helpers
 alias bro-column="sed \"s/fields.//;s/types.//\" | column -s $'\t' -t"
 alias bro-awk='awk -F" "'


### PR DESCRIPTION
 *  Removed  `pathmunge` so `/usr/sbin/broctl` takes precedence.
 *  Symliked `rock_*` scripts into `/usr/sbin` so they're in root's path.