### PR TITLE
Added explicit import of CentOS GPG key:

### DIFF
--- a/playbooks/deploy-rock.yml
+++ b/playbooks/deploy-rock.yml
@@ -117,6 +117,11 @@
       gpgcheck: yes
     when: rock_online_install
 
+  - name: Manually trust CentOS GPG key
+    shell: >
+      rpm --import http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
+    when: rock_online_install
+
   - name: Setup ELrepo Kernel repo
     yum_repository:
       name: elrepo-kernel


### PR DESCRIPTION
 *  Only when doing online install.
 *  Probably due to no gpgurl being specified for CentOS repos.
 *  Went with this because its a tested fix from @kwilson7770.
Fixes #142
Fixes #151