### PR TITLE
Create logstash-999-output.conf

### DIFF
--- a/playbooks/files/logstash-999-output.conf
+++ b/playbooks/files/logstash-999-output.conf
@@ -1,0 +1,39 @@
+output {
+    if [@metadata][stage] == "broraw_kafka" {
+        kafka {
+        codec => json
+        topic_id => "bro-clean"
+        bootstrap_servers => "127.0.0.1:9092"
+        }
+
+        elasticsearch {
+            hosts => ["127.0.0.1"]
+            index => "bro-%{+YYYY.MM.dd}"
+            document_type => "%{[@meta][event_type]}"
+            manage_template => false
+        }
+    }
+    else if [@metadata][stage] == "suricata_eve" {
+        #stdout { codec => rubydebug }
+        elasticsearch {
+            hosts => ["127.0.0.1"]
+            index => "suricata-%{+YYYY.MM.dd}"
+            document_type => "%{event_type}"
+        }
+    }
+    else if [@metadata][stage] == "fsf" {
+        #stdout { codec => rubydebug }
+        elasticsearch {
+            hosts => ["127.0.0.1"]
+            index => "fsf-%{+YYYY.MM.dd}"
+            document_type => "fsf"
+        }
+    }
+    else if "[@meta][stage]" == "_parsefailure" {
+        elasticsearch {
+            hosts => ["127.0.0.1"]
+            index => "parse-failures-%{+YYYY.MM.dd}"
+            document_type => "_parsefailure"
+        }
+    }
+}

--- a/playbooks/files/logstash-999-output.conf
+++ b/playbooks/files/logstash-999-output.conf
@@ -29,7 +29,7 @@ output {
             document_type => "fsf"
         }
     }
-    else if "[@meta][stage]" == "_parsefailure" {
+    else if [@metadata][stage] == "_parsefailure" {
         elasticsearch {
             hosts => ["127.0.0.1"]
             index => "parse-failures-%{+YYYY.MM.dd}"


### PR DESCRIPTION
1) In order to perform correct ordering of logstash files, and not duplicate certain filters/checks than numbering is necessary. Logstash loads files in order, after filter/input/output are merged.
2) Adding changes to move input and output to their own files.
3) Adding changes to not drop _parsefailures, but instead change their name and output to another index.