### PR TITLE
Create logstash-100-input.conf

### DIFF
--- a/playbooks/files/logstash-100-input.conf
+++ b/playbooks/files/logstash-100-input.conf
@@ -1,0 +1,22 @@
+input {
+    kafka {
+    topics => ["bro-raw"]
+    add_field => { "[@metadata][stage]" => "broraw_kafka" }
+    # Set this to one per kafka partition to scale up
+    #consumer_threads => 4
+    group_id => "bro_logstash"
+    bootstrap_servers => "127.0.0.1:9092"
+    codec => json
+    auto_offset_reset => "earliest"
+    }
+    file {
+        codec => "json"
+        path => "/data/suricata/eve.json"
+        add_field => { "[@metadata][stage]" => "suricata_eve" }
+    }
+    file {
+        codec => "json"
+        path => "/data/fsf/rockout.log"
+        add_field => { "[@metadata][stage]" => "fsf" }
+    }
+}


### PR DESCRIPTION
1) In order to perform correct ordering of logstash files, and not duplicate certain filters/checks than numbering is necessary. Logstash loads files in order, after filter/input/output are merged.
2) Adding changes to move input and output to their own files.
3) Adding changes to not drop _parsefailures, but instead change their name and output to another index.