### PR TITLE
Create logstash-998-parse-failures.conf

### DIFF
--- a/playbooks/files/logstash-998-parse-failures.conf
+++ b/playbooks/files/logstash-998-parse-failures.conf
@@ -1,0 +1,13 @@
+filter {
+    # In case [tags] are being used for something else and or geoip lookup failures, then we do NOT want to just assume [tags] means something we don't want to index.
+    # However, we also do NOT want to perform the expensive multi or statement on everything that does not have [tags]
+    if [tags] {
+        if "_parsefailure" in [tags] or "_jsonparsefailure" in [tags] or "_grokparsefailure" in [tags] or "_dissectfailure" in [tags] or "_groktimeout" in [tags] or "_rubyexception" in [tags] or "_dateparsefailure" in [tags] or "_jdbcstreamingfailure" in [tags] or "_elasticsearch_lookup_failure" in [tags] or "_urldecodefailure" in [tags] or "_csvparsefailure" in [tags] or "_xmlparsefailure" in [tags] {
+            mutate {
+                update => {
+                    "[@metadata][stage]" => "_parsefailure"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
checks to see if parse failures of any type then adds [@metadata][stage] => "_parsefailure" so it can be dropped in the correct index