### PR TITLE
Create es-parse-failures-mappings.json

### DIFF
--- a/playbooks/files/es-parse-failures-mappings.json
+++ b/playbooks/files/es-parse-failures-mappings.json
@@ -1,0 +1,39 @@
+{
+    "order": 99,
+    "template": "parse-failures-*",
+    "version": 1,
+    "settings": {
+        "index.mapping.ignore_malformed": true,
+        "index.mapping.total_fields.limit": 500,
+        "index.mapping.coerce": false,
+        "refresh_interval": "45s",
+        "number_of_replicas": "0"
+    },
+    "mappings": {
+        "_default_": {
+            "dynamic_templates": [
+                {
+                    "all_fields": {
+                        "match_mapping_type": "*",
+                        "mapping": {
+                            "type": "keyword",
+                            "include_in_all": false,
+                            "ignore_above": 256,
+                            "index": true,
+                            "norms": false,
+                            "analyzer": "keyword"
+                        }
+                    }
+                }
+            ],
+            "_all": {
+                "enabled": false
+            },
+            "properties": {
+                "@timestamp": {
+					"type": "date"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Mappings for the parse failure index from the other logstash pull requests.
This will enablemapping all fields as a "keyword" so as not to use any elasticsearch default "coerce"(ing) and "standard" analyzers.
The only type specified is "@timestamp" which is a date ---- of when the log was received.
Also, set to not replicate ("number_of_replicas": 0) as no need to take up space for parse failures/errors.
Note when testing "POST"ing / adding to this index that it won't refresh in Kibana/Elasticsearch until 45 seconds (specified in "refresh_interval")