### PR TITLE
Fix error in rock_status if ethtool -S lists string several times

### DIFF
--- a/playbooks/files/rock_status
+++ b/playbooks/files/rock_status
@@ -26,9 +26,9 @@ function feature_enabled() {
 
   # Timeout after 5 seconds or 5 packets
   for interface in $MON_IFS; do
-    packets_1=$(ethtool -S ${interface} | awk '/rx_packets/ {print $2}')
+    packets_1=$(ethtool -S ${interface} | grep -m1 "rx_packets" | awk '/rx_packets/ {print $2}') 
     sleep ${timeout_sec}
-    packets_2=$(ethtool -S ${interface} | awk '/rx_packets/ {print $2}')
+    packets_2=$(ethtool -S ${interface} | grep -m1 "rx_packets" | awk '/rx_packets/ {print $2}')
     packets=$(echo `expr ${packets_2} - ${packets_1}`)
     echo "${interface} had ${packets} packets in ${timeout_sec} secs."
     [ $packets -gt 0 ]
@@ -46,7 +46,7 @@ function feature_enabled() {
 
 @test "Check monitor interface for tx packets" {
   for interface in $MON_IFS; do
-    pkts=$(ethtool -S ${interface} | awk '/tx_packets/ {print $2}')
+    pkts=$(ethtool -S ${interface} | grep -m1 "tx_packets"| awk '/tx_packets/ {print $2}')
     echo "WARNING: Monitor interface ${interface} has sent ${pkts} packets".
     [ $pkts -eq 0 ]
   done

--- a/playbooks/files/rock_status
+++ b/playbooks/files/rock_status
@@ -26,9 +26,9 @@ function feature_enabled() {
 
   # Timeout after 5 seconds or 5 packets
   for interface in $MON_IFS; do
-    packets_1=$(ethtool -S ${interface} | grep -m1 "rx_packets" | awk '/rx_packets/ {print $2}') 
+    packets_1=$(cat /sys/class/net/${interface}/statistics/rx_packets) 
     sleep ${timeout_sec}
-    packets_2=$(ethtool -S ${interface} | grep -m1 "rx_packets" | awk '/rx_packets/ {print $2}')
+    packets_2=$(cat /sys/class/net/${interface}/statistics/rx_packets) 
     packets=$(echo `expr ${packets_2} - ${packets_1}`)
     echo "${interface} had ${packets} packets in ${timeout_sec} secs."
     [ $packets -gt 0 ]
@@ -37,7 +37,9 @@ function feature_enabled() {
 
 @test "Check for interface errors" {
   for interface in $MON_IFS; do
-    count=$(ethtool -S ${interface} | awk '/error/ && $2 > 0' | wc -l )
+    tx_errors=$(cat /sys/class/net/${interface}/statistics/tx_errors)
+    rx_errors=$(cat /sys/class/net/${interface}/statistics/rx_errors)
+    count=$(echo `expr ${tx_errors} + ${rx_errors}`)
     echo "${interface} had ${count} error types."
     echo ">> Check \`ethtool -S ${interface} | awk '/error/' \`  << "
     [ $count -eq 0 ]
@@ -46,7 +48,7 @@ function feature_enabled() {
 
 @test "Check monitor interface for tx packets" {
   for interface in $MON_IFS; do
-    pkts=$(ethtool -S ${interface} | grep -m1 "tx_packets"| awk '/tx_packets/ {print $2}')
+    pkts=$(cat /sys/class/net/${interface}/statistics/tx_packets)
     echo "WARNING: Monitor interface ${interface} has sent ${pkts} packets".
     [ $pkts -eq 0 ]
   done


### PR DESCRIPTION
> ethtool -S enp66s0f0

```
NIC statistics:
     rx_packets: 0
     tx_packets: 0
     rx_bytes: 0
     tx_bytes: 0
     rx_errors: 0
     tx_errors: 0
     rx_dropped: 0
     tx_dropped: 0
     collisions: 0
     rx_length_errors: 0
     rx_crc_errors: 0
     rx_unicast: 0
     tx_unicast: 0
     rx_multicast: 0
     tx_multicast: 0
     rx_broadcast: 0
     tx_broadcast: 0
     rx_unknown_protocol: 0
     tx_linearize: 0
     tx_force_wb: 0
     tx_lost_interrupt: 0
     rx_alloc_fail: 0
     rx_pg_alloc_fail: 0
     tx-0.tx_packets: 0
     tx-0.tx_bytes: 0
     rx-0.rx_packets: 0
     rx-0.rx_bytes: 0
     tx-1.tx_packets: 0
     tx-1.tx_bytes: 0
     rx-1.rx_packets: 0
     rx-1.rx_bytes: 0
     tx-2.tx_packets: 0
     tx-2.tx_bytes: 0
     rx-2.rx_packets: 0
     rx-2.rx_bytes: 0
     tx-3.tx_packets: 0
     tx-3.tx_bytes: 0
     rx-3.rx_packets: 0
     rx-3.rx_bytes: 0
     tx-4.tx_packets: 0
     tx-4.tx_bytes: 0
     rx-4.rx_packets: 0
     rx-4.rx_bytes: 0
     tx-5.tx_packets: 0
     tx-5.tx_bytes: 0
     rx-5.rx_packets: 0
     rx-5.rx_bytes: 0
     tx-6.tx_packets: 0
     tx-6.tx_bytes: 0
     rx-6.rx_packets: 0
     rx-6.rx_bytes: 0
     tx-7.tx_packets: 0
     tx-7.tx_bytes: 0
     rx-7.rx_packets: 0
     rx-7.rx_bytes: 0
     tx-8.tx_packets: 0
     tx-8.tx_bytes: 0
     rx-8.rx_packets: 0
     rx-8.rx_bytes: 0
     tx-9.tx_packets: 0
     tx-9.tx_bytes: 0
     rx-9.rx_packets: 0
     rx-9.rx_bytes: 0
     tx-10.tx_packets: 0
     tx-10.tx_bytes: 0
     rx-10.rx_packets: 0
     rx-10.rx_bytes: 0
     tx-11.tx_packets: 0
     tx-11.tx_bytes: 0
     rx-11.rx_packets: 0
     rx-11.rx_bytes: 0
     tx-12.tx_packets: 0
     tx-12.tx_bytes: 0
     rx-12.rx_packets: 0
     rx-12.rx_bytes: 0
     tx-13.tx_packets: 0
     tx-13.tx_bytes: 0
     rx-13.rx_packets: 0
     rx-13.rx_bytes: 0
     tx-14.tx_packets: 0
     tx-14.tx_bytes: 0
     rx-14.rx_packets: 0
     rx-14.rx_bytes: 0
     tx-15.tx_packets: 0
     tx-15.tx_bytes: 0
     rx-15.rx_packets: 0
     rx-15.rx_bytes: 0
     tx-16.tx_packets: 0
     tx-16.tx_bytes: 0
     rx-16.rx_packets: 0
     rx-16.rx_bytes: 0
     tx-17.tx_packets: 0
     tx-17.tx_bytes: 0
     rx-17.rx_packets: 0
     rx-17.rx_bytes: 0
     tx-18.tx_packets: 0
     tx-18.tx_bytes: 0
     rx-18.rx_packets: 0
     rx-18.rx_bytes: 0
     tx-19.tx_packets: 0
     tx-19.tx_bytes: 0
     rx-19.rx_packets: 0
     rx-19.rx_bytes: 0
     tx-20.tx_packets: 0
     tx-20.tx_bytes: 0
     rx-20.rx_packets: 0
     rx-20.rx_bytes: 0
     tx-21.tx_packets: 0
     tx-21.tx_bytes: 0
     rx-21.rx_packets: 0
     rx-21.rx_bytes: 0
     tx-22.tx_packets: 0
     tx-22.tx_bytes: 0
     rx-22.rx_packets: 0
     rx-22.rx_bytes: 0
     tx-23.tx_packets: 0
     tx-23.tx_bytes: 0
     rx-23.rx_packets: 0
     rx-23.rx_bytes: 0
     tx-24.tx_packets: 0
     tx-24.tx_bytes: 0
     rx-24.rx_packets: 0
     rx-24.rx_bytes: 0
     tx-25.tx_packets: 0
     tx-25.tx_bytes: 0
     rx-25.rx_packets: 0
     rx-25.rx_bytes: 0
     tx-26.tx_packets: 0
     tx-26.tx_bytes: 0
     rx-26.rx_packets: 0
     rx-26.rx_bytes: 0
     tx-27.tx_packets: 0
     tx-27.tx_bytes: 0
     rx-27.rx_packets: 0
     rx-27.rx_bytes: 0
     tx-28.tx_packets: 0
     tx-28.tx_bytes: 0
     rx-28.rx_packets: 0
     rx-28.rx_bytes: 0
     tx-29.tx_packets: 0
     tx-29.tx_bytes: 0
     rx-29.rx_packets: 0
     rx-29.rx_bytes: 0
     tx-30.tx_packets: 0
     tx-30.tx_bytes: 0
     rx-30.rx_packets: 0
     rx-30.rx_bytes: 0
     tx-31.tx_packets: 0
     tx-31.tx_bytes: 0
     rx-31.rx_packets: 0
     rx-31.rx_bytes: 0
     port.rx_bytes: 0
     port.tx_bytes: 0
     port.rx_unicast: 0
     port.tx_unicast: 0
     port.rx_multicast: 0
     port.tx_multicast: 0
     port.rx_broadcast: 0
     port.tx_broadcast: 0
     port.tx_errors: 0
     port.rx_dropped: 0
     port.tx_dropped_link_down: 0
     port.rx_crc_errors: 0
     port.illegal_bytes: 0
     port.mac_local_faults: 0
     port.mac_remote_faults: 0
     port.tx_timeout: 0
     port.rx_csum_bad: 0
     port.rx_length_errors: 0
     port.link_xon_rx: 0
     port.link_xoff_rx: 0
     port.link_xon_tx: 0
     port.link_xoff_tx: 0
     port.rx_size_64: 0
     port.rx_size_127: 0
     port.rx_size_255: 0
     port.rx_size_511: 0
     port.rx_size_1023: 0
     port.rx_size_1522: 0
     port.rx_size_big: 0
     port.tx_size_64: 0
     port.tx_size_127: 0
     port.tx_size_255: 0
     port.tx_size_511: 0
     port.tx_size_1023: 0
     port.tx_size_1522: 0
     port.tx_size_big: 0
     port.rx_undersize: 0
     port.rx_fragments: 0
     port.rx_oversize: 0
     port.rx_jabber: 0
     port.VF_admin_queue_requests: 0
     port.arq_overflows: 0
     port.rx_hwtstamp_cleared: 0
     port.fdir_flush_cnt: 0
     port.fdir_atr_match: 0
     port.fdir_atr_tunnel_match: 0
     port.fdir_atr_status: 1
     port.fdir_sb_match: 0
     port.fdir_sb_status: 1
     port.tx_lpi_status: 0
     port.rx_lpi_status: 0
     port.tx_lpi_count: 0
     port.rx_lpi_count: 0
     port.tx_priority_0_xon: 0
     port.tx_priority_0_xoff: 0
     port.tx_priority_1_xon: 0
     port.tx_priority_1_xoff: 0
     port.tx_priority_2_xon: 0
     port.tx_priority_2_xoff: 0
     port.tx_priority_3_xon: 0
     port.tx_priority_3_xoff: 0
     port.tx_priority_4_xon: 0
     port.tx_priority_4_xoff: 0
     port.tx_priority_5_xon: 0
     port.tx_priority_5_xoff: 0
     port.tx_priority_6_xon: 0
     port.tx_priority_6_xoff: 0
     port.tx_priority_7_xon: 0
     port.tx_priority_7_xoff: 0
     port.rx_priority_0_xon: 0
     port.rx_priority_0_xoff: 0
     port.rx_priority_1_xon: 0
     port.rx_priority_1_xoff: 0
     port.rx_priority_2_xon: 0
     port.rx_priority_2_xoff: 0
     port.rx_priority_3_xon: 0
     port.rx_priority_3_xoff: 0
     port.rx_priority_4_xon: 0
     port.rx_priority_4_xoff: 0
     port.rx_priority_5_xon: 0
     port.rx_priority_5_xoff: 0
     port.rx_priority_6_xon: 0
     port.rx_priority_6_xoff: 0
     port.rx_priority_7_xon: 0
     port.rx_priority_7_xoff: 0
     port.rx_priority_0_xon_2_xoff: 0
     port.rx_priority_1_xon_2_xoff: 0
     port.rx_priority_2_xon_2_xoff: 0
     port.rx_priority_3_xon_2_xoff: 0
     port.rx_priority_4_xon_2_xoff: 0
     port.rx_priority_5_xon_2_xoff: 0
     port.rx_priority_6_xon_2_xoff: 0
     port.rx_priority_7_xon_2_xoff: 0
```
