### PR TITLE
Add playbook for setting up user auth

### DIFF
--- a/playbooks/auth-mgmt.yml
+++ b/playbooks/auth-mgmt.yml
@@ -1,0 +1,19 @@
+---
+
+- hosts: all
+  become: true
+  vars_files:
+    - /etc/rocknsm/config.yml
+  tasks:
+  - name: Set authorized keys
+    authorized_key:
+      user: "{{ ansible_env.SUDO_USER }}"
+      state: present
+      key: "{{ public_keys }}"
+
+  - name: Enable sudo w/o password
+    lineinfile:
+     path: /etc/sudoers
+     state: present
+     regexp: '^{{ ansible_env.SUDO_USER }}\s'
+     line: '{{ ansible_env.SUDO_USER }} ALL=(ALL) NOPASSWD: ALL'


### PR DESCRIPTION
This is a one-off playbook to make user auth less painful when doing a multinode deployment. Will require a docs update.