### PR TITLE
fix for #346

### DIFF
--- a/playbooks/files/rockctl
+++ b/playbooks/files/rockctl
@@ -1,7 +1,19 @@
 #!/bin/bash
 
 action=$1
-psprocs=( zookeeper kafka bro suricata filebeat elasticsearch logstash kibana stenographer )
+psprocs=( zookeeper kafka bro suricata filebeat elasticsearch logstash kibana stenographer fsf docket )
+
+function feature_enabled() {
+  if grep -qiE "^with_$1: (true|yes)" /etc/rocknsm/config.yml; then
+    if grep -qiE "^enable_$1: (true|yes)" /etc/rocknsm/config.yml; then
+      return $?
+    else
+      false
+    fi
+  else
+    false
+  fi
+}
 
 function reverse()
 {
@@ -24,12 +36,26 @@ case $action in
     for proc in "${psprocs[@]}"; do
       echo "${proc^^}: stopping..."
       systemctl stop ${proc}
+      # Lets also make sure the service is disabled
+      if [[ $(systemctl is-enabled ${proc}) == 'enabled' ]] && ! $(feature_enabled ${proc}); then
+        echo "${proc^^} is set to disabled in RockNSM config but is currently enabled in systemctl."
+        echo "Disabling ${proc^^} in systemctl..."
+        systemctl disable --quiet ${proc}
+      fi
     done
     ;;
   "start")
     for proc in "${psprocs[@]}"; do
-      echo "${proc^^}: starting..."
-      systemctl start ${proc}
+      if feature_enabled ${proc}; then
+        echo "${proc^^}: starting..."
+        systemctl start ${proc}
+        # Lets also make sure the service is enabled
+        if [[ $(systemctl is-enabled ${proc}) == 'disabled' ]]; then
+          echo "${proc^^} is set to enabled in RockNSM config but is currently disabled in systemctl."
+          echo "Enabling ${proc^^} in systemctl..."
+          systemctl enable ${proc}
+        fi
+      fi
     done
     ;;
   "status")


### PR DESCRIPTION
#### /etc/rocknsm/config.yml
```
### Advanced Feature Selection ######
# Don't flip these unless you know what you're doing
with_stenographer: True
with_docket: True
with_bro: True
with_suricata: True
with_snort: False
with_suricata_update: True
with_logstash: True
with_elasticsearch: True
with_kibana: True
with_zookeeper: True
with_kafka: True
with_lighttpd: True
with_fsf: True

# Specify if a service is enabled on startup
enable_stenographer: False
enable_docket: False
enable_bro: True
enable_suricata: False
enable_snort: False
enable_suricata_update: False
enable_logstash: True
enable_elasticsearch: True
enable_kibana: False
enable_zookeeper: True
enable_kafka: True
enable_lighttpd: True
enable_fsf: False
```

##### output after rockctl stop change with config above
```
[bobs-ya-uncle@simplerockbuild bobs-ya-uncle]# sudo rockctl stop
STENOGRAPHER@ENP0S8: stopping...
DOCKET: stopping...
DOCKET is set to disabled in RockNSM config but is currently enabled in systemctl.
Disabling DOCKET in systemctl...
FSF: stopping...
FSF is set to disabled in RockNSM config but is currently enabled in systemctl.
Disabling FSF in systemctl...
STENOGRAPHER: stopping...
STENOGRAPHER is set to disabled in RockNSM config but is currently enabled in systemctl.
Disabling STENOGRAPHER in systemctl...
KIBANA: stopping...
LOGSTASH: stopping...
ELASTICSEARCH: stopping...
FILEBEAT: stopping...
SURICATA: stopping...
SURICATA is set to disabled in RockNSM config but is currently enabled in systemctl.
Disabling SURICATA in systemctl...
BRO: stopping...
KAFKA: stopping...
ZOOKEEPER: stopping...
```

##### output after rockctl start change and changing a service to enable_$service True
```
# Changing 'enable_suricata: True' (from false) -- simulating a user wanting to later enable a service

[bobs-ya-uncle@simplerockbuild bobs-ya-uncle]# sudo rockctl start
ZOOKEEPER: starting...
KAFKA: starting...
BRO: starting...
SURICATA: starting...
SURICATA is set to enabled in RockNSM config but is currently disabled in systemctl.
Enabling SURICATA in systemctl...
Created symlink from /etc/systemd/system/multi-user.target.wants/suricata.service to /etc/systemd/system/suricata.service.
ELASTICSEARCH: starting...
LOGSTASH: starting...
```