### PR TITLE
Fix hostname cruft across roles

### DIFF
--- a/playbooks/debug.yml
+++ b/playbooks/debug.yml
@@ -10,8 +10,6 @@
 - debug: var=es_mem
 - debug: var=bro_cpu
 - debug: var=rock_monifs
-- debug: var=rock_hostname
-- debug: var=rock_fqdn
 - debug: var=epel_baseurl
 - debug: var=epel_gpgurl
 - debug: var=elastic_baseurl

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -19,7 +19,6 @@ rock_data_user: root
 rock_data_group: root
 rock_monifs: "{{ ansible_interfaces | difference(['lo', ansible_default_ipv4.interface | default('lo') ])| list }}"
 rock_hostname: "{{ inventory_hostname_short }}"
-rock_fqdn: "{{ inventory_hostname }}"
 rock_mgmt_nets: [ "0.0.0.0/0" ]
 rock_cache_dir: /srv/rocknsm/support
 rock_debug: "{{ lookup('env', 'DEBUG') }}"
@@ -142,7 +141,7 @@ es_user: elasticsearch
 es_group: elasticsearch
 es_data_dir: "{{ rock_data_dir }}/elasticsearch"
 es_cluster_name: rocknsm
-es_node_name: "{{ rock_hostname }}"
+es_node_name: "{{ ansible_hostname }}"
 es_network_host: "{{ '_site:ipv4_' if ( groups['elasticsearch'] | length ) > 1 else '_local:ipv4_' }}"
 es_url: "http://{{ groups['elasticsearch'][0] if ( groups['elasticsearch'] | length ) > 1 else '127.0.0.1' }}:9200"
 es_action_auto_create_index: true

--- a/playbooks/templates/rock_config.yml.j2
+++ b/playbooks/templates/rock_config.yml.j2
@@ -28,11 +28,7 @@ rock_monifs:
 ###############################################################################
 #                         Sensor Resource Configuration
 ###############################################################################
-# Set the hostname of the sensor:
-rock_hostname: {{ rock_hostname }}
-
-# Set the Fully Qualified Domain Name:
-rock_fqdn: {{ rock_fqdn }}
+# Set hostname and fqdn in inventory file
 
 # Set the number of CPUs assigned to Bro:
 bro_cpu: {{ bro_cpu }}

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -69,14 +69,22 @@
   notify:
   - Restart sshd
 
-- name: Update hosts file with inventory
-  template:
-    src: hosts.j2
+- name: Add the inventory into /etc/hosts
+  lineinfile:
     dest: /etc/hosts
+    regexp: '.*{{ item }}$'
+    line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }} {{item}}"
+    state: present
+  when: hostvars[item]['ansible_facts']['default_ipv4'] is defined
+  with_items:
+    - "{{ groups['all'] }}"
 
 - name: Set system hostname
   hostname:
-    name: "{{ rock_fqdn }}"
+    name: "{{ inventory_hostname }}"
+
+- name: Re-run Setup to populate changes
+  setup:
 
 - name: Setup EPEL repository
   yum_repository:

--- a/roles/common/templates/hosts.j2
+++ b/roles/common/templates/hosts.j2
@@ -1,7 +1,0 @@
-{{ ansible_managed }}
-
-127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
-
-{% for host in ( play_hosts | sort ) %}
-{{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_hostname }}
-{% endfor %}

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -3,7 +3,7 @@ es_user: elasticsearch
 es_group: elasticsearch
 es_data_dir: "{{ rock_data_dir }}/elasticsearch"
 es_cluster_name: rocknsm
-es_node_name: "{{ rock_hostname }}"
+es_node_name: "{{ ansible_hostname }}"
 es_network_host: "{{ '_site:ipv4_' if ( groups['elasticsearch'] | length ) > 1 else '_local:ipv4_' }}"
 es_action_auto_create_index: true
 es_min_master_nodes: "{{ 2 if ( groups['es_masters'] | length ) == 3 else 1 }}"

--- a/roles/lighttpd/tasks/main.yml
+++ b/roles/lighttpd/tasks/main.yml
@@ -59,7 +59,7 @@
     organization_name: RockNSM
     organizational_unit_name: NSM Ninjas
     email_address: info@rocknsm.io
-    common_name: "{{ rock_fqdn }}"
+    common_name: "{{ ansible_hostname }}"
   when: with_kibana
   notify: Enable and restart lighttpd
 

--- a/roles/sensor-defaults/defaults/main.yml
+++ b/roles/sensor-defaults/defaults/main.yml
@@ -8,8 +8,6 @@ rocknsm_dir: /opt/rocknsm
 rock_data_user: root
 rock_data_group: root
 rock_monifs: "{{ ansible_interfaces | difference(['lo', ansible_default_ipv4.interface | default('lo') ])| list }}"
-rock_hostname: "{{ inventory_hostname_short }}"
-rock_fqdn: "{{ inventory_hostname }}"
 rock_mgmt_nets: [ "0.0.0.0/0" ]
 rock_cache_dir: /srv/rocknsm/support
 pulledpork_rules:
@@ -143,7 +141,7 @@ es_group: elasticsearch
 es_data_dir: "{{ rock_data_dir }}/elasticsearch"
 es_log_dir: /var/log/elasticsearch
 es_cluster_name: rocknsm
-es_node_name: "{{ rock_hostname }}"
+es_node_name: "{{ ansible_hostname }}"
 es_mem: "{{ (ansible_memtotal_mb // 1024 // 2) if (ansible_memtotal_mb // 1024) < 64 else 31 }}"
 es_url: "http://localhost:9200"
 es_memlock_override: |


### PR DESCRIPTION
- We were using various hostname vars across multiple roles, making it a 
big clunky
- Making the inventory_hostname the authoriative source, set the 
hostname and set /etc/hosts accordingly

- Fixes #357 