### PR TITLE
Configure UI_WEB_ROOT, enabling redirects for URI API

### DIFF
--- a/roles/docket/templates/docket_prod.yaml.j2
+++ b/roles/docket/templates/docket_prod.yaml.j2
@@ -25,6 +25,7 @@ SPOOL_DIR: {{ docket_spool_dir }}
 #     http://HOST:PORT/api/stats/
 #     http://HOST:PORT/api/uri/host/1.2.3.4/
 WEB_ROOT: {{ docket_url_apppath }}/api
+UI_WEB_ROOT: {{ docket_url_apppath }}
 # WEB_ROOT  the base url for PCAP requests: default is /results
 #  example:
 #     http://HOST:PORT/results/<JOB_ID>/merged.pcap


### PR DESCRIPTION
Pairs with Docket 1.0.2 fix, enabling relocating Docket frontend. This is needed for the redirects after a URI API query to land on the correct page.