### PR TITLE
Use variable config path

### DIFF
--- a/playbooks/auth-mgmt.yml
+++ b/playbooks/auth-mgmt.yml
@@ -5,7 +5,7 @@
   vars:
     - public_keys: "{{ lookup('file', ansible_user_dir'/.ssh/id_rsa.pub') }}"
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
   tasks:
   - name: Set authorized keys
     authorized_key:

--- a/playbooks/auth-mgmt.yml
+++ b/playbooks/auth-mgmt.yml
@@ -3,7 +3,7 @@
 - hosts: all
   become: true
   vars:
-    - public_keys: "{{ lookup('file', ansible_user_dir'/.ssh/id_rsa.pub') }}"
+    - public_keys: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
   vars_files:
     - "{{ rock_config }}"
   tasks:

--- a/playbooks/delete-data.yml
+++ b/playbooks/delete-data.yml
@@ -8,7 +8,7 @@
   - name: Get default settings
     include_vars: rocknsm_config.dist.yml
   - name: Apply override settings, if available
-    include_vars: /etc/rocknsm/config.yml
+    include_vars: "{{ rock_config }}"
     ignore_errors: true
     failed_when: false
   - name: Debug variables

--- a/playbooks/deploy-rock.yml
+++ b/playbooks/deploy-rock.yml
@@ -1,27 +1,31 @@
 ---
 - hosts: all
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - common
 
 - hosts: zookeeper
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: zookeeper
       when: "'zookeeper' in installed_services"
 
 - hosts: kafka
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: kafka
       when: "'kafka' in installed_services"
 
 - hosts: stenographer
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: stenographer
       when: "'stenographer' in installed_services"
@@ -29,21 +33,24 @@
 
 - hosts: bro
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: bro
       when: "'bro' in installed_services"
 
 - hosts: suricata
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: suricata
       when: "'suricata' in installed_services"
 
 - hosts: fsf
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: fsf
       when: "'fsf' in installed_services"
@@ -52,7 +59,8 @@
     - docket
     - kibana
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: lighttpd
       when: "'lighttpd' in installed_services"
@@ -61,7 +69,8 @@
     - docket
     - stenographer
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: docket
       when: "'docket' in installed_services"
@@ -69,21 +78,24 @@
 
 - hosts: elasticsearch
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: elasticsearch
       when: "'elasticsearch' in installed_services"
 
 - hosts: logstash
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: logstash
       when: "'logstash' in installed_services"
 
 - hosts: kibana
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
+  become: True
   roles:
     - role: kibana
       when: "'kibana' in installed_services"

--- a/playbooks/generate-defaults.yml
+++ b/playbooks/generate-defaults.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  become: True
   tasks:
   - name: Create config directory
     file:
@@ -7,13 +8,13 @@
       owner: root
       group: root
       mode:  0755
-      path: /etc/rocknsm
+      path: "{{ rock_conf_dir }}"
 
   - name: Render template
     template:
       backup: yes
       src: rock_config.yml.j2
-      dest: /etc/rocknsm/config.yml
+      dest: "{{ rock_config }}"
       owner: root
       group: root
       mode: 0644

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -14,6 +14,7 @@ rock_disable_offline_repo: false
 rock_sysctl_file: /etc/sysctl.d/10-ROCK.conf
 rock_data_dir: /data
 rock_conf_dir: /etc/rocknsm
+rock_config: "{{ rock_conf_dir }}/config.yml"
 rocknsm_dir: /opt/rocknsm
 rock_data_user: root
 rock_data_group: root

--- a/playbooks/manage-services.yml
+++ b/playbooks/manage-services.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   vars_files:
-    - /etc/rocknsm/config.yml
+    - "{{ rock_config }}"
   tasks:
     - name: Populate service facts
       service_facts:


### PR DESCRIPTION
When doing integration testing or remote deployment of a RockNSM host(s), it's helpful to place the ROCK `config.yml` in a user-defined spot. Specifically, I needed this to enable `molecule` testing.