### PR TITLE
remote deploy role cleanup

### DIFF
--- a/roles/bro/handlers/main.yml
+++ b/roles/bro/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 # handlers file for Bro
 
-- name: Reload bro
-  service:
-    name: bro
-    state: "{{ 'started' if 'bro' in enabled_services else 'stopped' }}"
-
 - name: Configure monitor interfaces
   shell: >
     for intf in {{ rock_monifs | join(' ') }}; do
       /sbin/ifup ${intf};
     done
+
+- name: Reload bro
+  service:
+    name: bro
+    state: "{{ 'started' if 'bro' in enabled_services else 'stopped' }}"

--- a/roles/bro/tasks/main.yml
+++ b/roles/bro/tasks/main.yml
@@ -20,7 +20,7 @@
     owner: root
     group: root
     force: yes
-  with_items: "{{ rock_monifs }}"
+  loop: "{{ rock_monifs }}"
 
 - name: Configure local ifup script
   template:
@@ -64,7 +64,7 @@
     dest: "/usr/share/GeoIP/{{ item.dest }}"
     force: yes
     state: link
-  with_items:
+  loop:
     - { src: 'GeoLiteCity.dat', dest: 'GeoIPCity.dat' }
     - { src: 'GeoLiteCountry.dat', dest: 'GeoIPCountry.dat' }
     - { src: 'GeoLiteASNum.dat', dest: 'GeoIPASNum.dat' }
@@ -95,7 +95,7 @@
     group: "{{ bro_group }}"
     state: directory
     setype: var_log_t
-  with_items:
+  loop:
     - "{{ bro_data_dir }}"
     - "{{ bro_data_dir }}/logs"
     - "{{ bro_data_dir }}/spool"
@@ -234,7 +234,7 @@
     path: /usr/bin/bro
     capability: "{{ item }}"
     state: present
-  with_items:
+  loop:
     - "cap_net_raw+eip"
     - "cap_net_admin+eip"
 
@@ -243,7 +243,7 @@
     path: /usr/bin/capstats
     capability: "{{ item }}"
     state: present
-  with_items:
+  loop:
     - "cap_net_raw+eip"
     - "cap_net_admin+eip"
 
@@ -261,6 +261,19 @@
     creates: "{{ bro_data_dir }}/spool/broctl-config.sh"
   become: yes
   become_user: "{{ bro_user }}"
+
+- name: Check status of interfaces
+  command: >
+    /usr/sbin/ip -oneline link show dev {{ item }}
+  register: iplink
+  changed_when: False
+  loop: "{{ rock_monifs }}"
+
+- name: Bring up interfaces
+  command: >
+    /usr/sbin/ip -oneline link set dev {{ item.stdout.split(':')[1] | trim }} up
+  when: item.stdout is search("state DOWN")
+  loop:  "{{ iplink.results }}"
 
 - name: Enable and start bro
   service:

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -32,6 +32,15 @@
     group: root
     state: directory
 
+- name: Create RockNSM cache dir
+  file:
+    path: "{{ rock_cache_dir }}"
+    mode: 0755
+    owner: root
+    group: root
+    state: directory
+  when: inventory_hostname in groups.logstash
+
 - name: Download RockNSM elastic configs
   get_url:
     url: "{{ rock_dashboards_url }}"
@@ -76,8 +85,7 @@
     line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }} {{item}}"
     state: present
   when: hostvars[item]['ansible_facts']['default_ipv4'] is defined
-  with_items:
-    - "{{ groups['all'] }}"
+  loop: "{{ groups['all'] }}"
 
 - name: Set system hostname
   hostname:
@@ -110,29 +118,6 @@
     gpgcheck: no
   when: rock_online_install
 
-- name: Install RockNSM GPG keys
-  copy:
-    src: "{{ item }}"
-    dest: "/etc/pki/rpm-gpg/{{ item }}"
-    mode: 0644
-    owner: root
-    group: root
-  with_items:
-    - RPM-GPG-KEY-RockNSM-2
-    - RPM-GPG-KEY-RockNSM-Testing
-    - RPM-GPG-KEY-RockNSM-pkgcloud-2_3
-
-- name: Trust RockNSM GPG keys
-  rpm_key:
-    state: present
-    key: "{{ item.path }}"
-  with_items:
-    - { repoid: "rocknsm_2_3", path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-2" }
-    - { repoid: "rocknsm_2_3", path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-pkgcloud-2_3" }
-    - { repoid: "rocknsm-testing", path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-Testing"}
-    - { repoid: "rocknsm-local", path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-2" }
-  register: registered_keys
-
 - name: Configure RockNSM online repos
   yum_repository:
     file: rocknsm
@@ -150,7 +135,7 @@
     metadata_expire: 300
     cost: 750
     state: present
-  with_items:
+  loop:
     - { name: "rocknsm_2_3", gpgcheck: yes, baseurl: "{{ rocknsm_baseurl }}" }
     - { name: "rocknsm_2_3-source", gpgcheck: no, baseurl: "{{ rocknsm_srpm_baseurl }}" }
 
@@ -180,30 +165,58 @@
     cost: 500
   when: not rock_disable_offline_repo
 
-- name: Trust RockNSM GPG keys in yum
-  command: "yum -q makecache -y --disablerepo='*' --enablerepo='{{ item.repoid }}'"
-  with_items:
-    - { repoid: "rocknsm_2_3", test: "{{ rock_online_install }}" }
-    - { repoid: "rocknsm_2_3-source", test: "{{ rock_online_install }}" }
-    - { repoid: "rocknsm-testing", test: "{{ rock_online_install }}" }
-    - { repoid: "rocknsm-local", test: "{{ not rock_online_install }}" }
+- name: Install RockNSM GPG keys
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/pki/rpm-gpg/{{ item }}"
+    mode: 0644
+    owner: root
+    group: root
+  loop:
+    - RPM-GPG-KEY-RockNSM-2
+    - RPM-GPG-KEY-RockNSM-Testing
+    - RPM-GPG-KEY-RockNSM-pkgcloud-2_3
+
+- name: Trust RockNSM GPG keys for RPMs
+  rpm_key:
+    state: present
+    key: "{{ item.path }}"
+  loop:
+    - repoid: "rocknsm_2_3"
+      path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-2"
+      test: "{{ rock_online_install }}"
+    - repoid: "rocknsm_2_3"
+      path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-pkgcloud-2_3"
+      test: "{{ rock_online_install }}"
+    - repoid: "rocknsm-testing"
+      path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-Testing"
+      test: "{{ rock_online_install }}"
+    - repoid: "rocknsm-local"
+      path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-2"
+      test: "{{ not rock_disable_offline_repo }}"
+  register: registered_keys
   when: item.test | bool
-  changed_when: False
-  # TODO: Fix this ^^
+
+- name: Trust RockNSM GPG keys in yum
+  command: >
+    yum -q makecache -y --disablerepo='*' --enablerepo='{{ item.item.repoid }}'
+  args:
+    warn: false
+  loop: "{{ registered_keys.results }}"
+  when: item.changed
 
 - name: Configure default CentOS online repos
-  yum_repository:
-    name: "{{ item.name }}"
-    enabled: "{{ rock_online_install }}"
-    description: "CentOS-$releasever - {{ item.name | title }}"
-    mirrorlist: "{{ item.mirror }}"
-    gpgcheck: 1
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
-    file:  CentOS-Base
-  with_items:
-  - { name: base, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra" }
-  - { name: updates, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra" }
-  - { name: extras, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra"}
+  ini_file:
+    path: "{{ item.path }}"
+    section: "{{ item.repo }}"
+    option: "enabled"
+    value: "{{ '1' if rock_online_install else '0' }}"
+    state: "present"
+  loop:
+    - { path: "/etc/yum.repos.d/CentOS-Base.repo", repo: "base" }
+    - { path: "/etc/yum.repos.d/CentOS-Base.repo", repo: "updates" }
+    - { path: "/etc/yum.repos.d/CentOS-Base.repo", repo: "extras" }
+  when: ansible_distribution == "CentOS"
 
 - name: Install core packages
   yum:
@@ -252,7 +265,7 @@
 - name: Set RockNSM Version
   copy:
     content: "{{ rock_version }}"
-    dest: /etc/rocknsm/rock-version
+    dest: "{{ rock_conf_dir }}/rock-version"
     mode: 0644
     owner: root
     group: root

--- a/roles/docket/handlers/main.yml
+++ b/roles/docket/handlers/main.yml
@@ -10,7 +10,7 @@
   file:
     path: "{{steno_certs_dir}}/{{hostvars[item].inventory_hostname}}.csr"
     state: absent
-  with_items: "{{ groups['docket'] }}"
+  loop: "{{ groups['docket'] }}"
   when:
     - "{{ inventory_hostname in groups['stenographer'] | bool}}"
 
@@ -31,7 +31,7 @@
   service:
     name: "{{ item }}"
     state: restarted
-  with_items:
+  loop:
     - docket-celery-io
     - docket-celery-query
   when: docket_enable | bool

--- a/roles/docket/tasks/crypto.yml
+++ b/roles/docket/tasks/crypto.yml
@@ -62,7 +62,7 @@
     path: "{{docket_x509_dir}}/docket-{{inventory_hostname_short}}_sensor-{{item}}_cert.pem"
   register: docket_cert
   changed_when: false
-  with_items: "{{ groups['stenographer'] }}"
+  loop: "{{ groups['stenographer'] }}"
   when: inventory_hostname in groups['docket']
 
 - debug: var=docket_cert.results
@@ -95,14 +95,12 @@
     msg: "{{ hostvars[item].docket_cert|json_query('results[?stat.exists==`false`]')|length }}"
   when:
     - inventory_hostname in groups['stenographer']
-  with_items:
-    - "{{ groups['docket'] }}"
+  loop: "{{ groups['docket'] }}"
 
 - debug:
     var: hostvars[item].docket_cert|json_query('results[?item==inventory_hostname_short]')
     #selectattr("item", "equalto", inventory_hostname_short)|map(attribute="stat.exists")|select("equalto", false)|list|length
-  with_items:
-    - "{{ groups['docket'] }}"
+  loop: "{{ groups['docket'] }}"
   when:
     - inventory_hostname in groups['stenographer']
 
@@ -110,8 +108,7 @@
   copy:
     src: "{{ansible_cache}}/{{hostvars[item].inventory_hostname_short}}.csr"
     dest: "{{steno_certs_dir}}/{{hostvars[item].inventory_hostname_short}}.csr"
-  with_items:
-    - "{{ groups['docket'] }}"
+  loop: "{{ groups['docket'] }}"
   when:
     - inventory_hostname in groups['stenographer']
     #- hostvars[item].docket_cert.results|selectattr("item", "equalto", inventory_hostname_short)|map(attribute="stat.exists")|select("equalto",false)|list|length
@@ -123,7 +120,7 @@
     ownca_privatekey_path: "{{steno_ca_key}}"
     ownca_path: "{{steno_ca_cert}}"
     provider: ownca
-  with_items: "{{ groups['docket'] }}"
+  loop: "{{ groups['docket'] }}"
   when:
     - inventory_hostname in groups['stenographer']
     - hostvars[item].docket_cert.results|map(attribute="stat.exists")|select("equalto",false)|list|length
@@ -133,7 +130,7 @@
     src: "{{steno_certs_dir}}/docket-{{hostvars[item].inventory_hostname_short}}_sensor-{{inventory_hostname_short}}_cert.pem"
     dest: "{{ansible_cache}}/docket-{{hostvars[item].inventory_hostname_short}}_sensor-{{inventory_hostname_short}}_cert.pem"
     flat: yes
-  with_items: "{{ groups['docket'] }}"
+  loop: "{{ groups['docket'] }}"
   when:
     - inventory_hostname in groups['stenographer']
     - hostvars[item].docket_cert.results|map(attribute="stat.exists")|select("equalto",false)|list|length
@@ -154,7 +151,7 @@
     owner: "{{ docket_x509_user }}"
     group: "{{ docket_x509_group }}"
     mode: "0644"
-  with_items: "{{ groups['stenographer'] }}"
+  loop: "{{ groups['stenographer'] }}"
   when:
     - inventory_hostname in groups['docket']
     - docket_cert.results|map(attribute="stat.exists")|select("equalto",false)|list|length
@@ -166,7 +163,7 @@
     owner: "{{ docket_x509_user }}"
     group: "{{ docket_x509_group }}"
     mode: "0644"
-  with_items: "{{ groups['stenographer'] }}"
+  loop: "{{ groups['stenographer'] }}"
   when:
     - inventory_hostname in groups['docket']
 

--- a/roles/docket/tasks/docket_config.yml
+++ b/roles/docket/tasks/docket_config.yml
@@ -38,7 +38,7 @@
     name: "{{ item }}"
     enabled: "{{ 'True' if 'docket' in enabled_services else 'False' }}"
   notify: Restart docket celery services
-  with_items:
+  loop:
     - docket-celery-io
     - docket-celery-query
 

--- a/roles/docket/tasks/install.yml
+++ b/roles/docket/tasks/install.yml
@@ -16,7 +16,7 @@
     metadata_expire: 300
     cost: 750
     state: present
-  with_items:
+  loop:
     - { name: "rocknsm_2_3", gpgcheck: yes, baseurl: "{{ rocknsm_baseurl }}" }
     - { name: "rocknsm_2_3-source", gpgcheck: no, baseurl: "{{ rocknsm_srpm_baseurl }}" }
   when: "{{ docket_install == 'yumrepo' }}"

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -75,11 +75,18 @@
 - name: Flush handlers
   meta: flush_handlers
 
-- name: Wait for elasticsearch to become ready
-  wait_for:
-    host: "{{ ansible_host }}"
-    port: 9200
-  run_once: true
+- name: "Wait for Elasticsearch to be available"
+  uri:
+    url: "{{ es_url }}/_cluster/health"
+    status_code: 200
+  register: result
+  until: result.status == 200
+  retries: 60
+  delay: 5
+
+- fail:
+    msg: "Elasticsearch cluster has a red status"
+  when: result.json.status == "red"
 
 - name: Check for default mapping template
   uri:

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -10,7 +10,7 @@ bootstrap.memory_lock: true
 network.host: {{ es_network_host }}
 discovery.zen.minimum_master_nodes: {{ es_min_master_nodes }}
 
-{% if groups['elasticsearch'] > 1 %}
+{% if groups['elasticsearch']|length > 1 %}
 discovery.zen.ping.unicast.hosts:
 {% for host in query('inventory_hostnames', 'es_masters') %}
   - {{ host }}

--- a/roles/lighttpd/tasks/main.yml
+++ b/roles/lighttpd/tasks/main.yml
@@ -15,7 +15,7 @@
     owner: root
     group: root
   when: "'kibana' in installed_services"
-  with_items:
+  loop:
     - 10-rock-auth.conf
     - 10-tls.conf
     - 20-rock-vars.conf

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -16,7 +16,7 @@
     mode: 0640
   when: "'bro' and 'kafka' in installed_services"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-100-input-kafka-bro
     - logstash-999-output-es-bro
 
@@ -30,7 +30,7 @@
     remote_src: "yes"
   when: "'bro' and 'kafka' in installed_services"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-500-filter-bro.conf
 
 - name: Add suricata input/output for logstash
@@ -42,7 +42,7 @@
     mode: 0640
   when: "'suricata' and 'kafka' in installed_services"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-100-input-kafka-suricata
     - logstash-999-output-es-suricata
 
@@ -56,7 +56,7 @@
     remote_src: "yes"
   when: "'suricata' and 'kafka' in installed_services"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-500-filter-suricata.conf
 
 - name: Add fsf input/output for logstash
@@ -68,7 +68,7 @@
     mode: 0640
   when: "'fsf' and 'kafka' in installed_services"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-100-input-kafka-fsf
     - logstash-999-output-es-fsf
 
@@ -82,7 +82,7 @@
     remote_src: "yes"
   when: "'fsf' and 'kafka' in installed_services"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-500-filter-fsf.conf
 
 - name: Add parse failure input/output for logstash
@@ -93,7 +93,7 @@
     group: "{{ logstash_group }}"
     mode: 0640
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-999-output-es-parsefailures
 
 - name: Install parse failure configuration for logstash
@@ -105,7 +105,7 @@
     group: "{{ logstash_group }}"
     remote_src: "yes"
   notify: Restart logstash
-  with_items:
+  loop:
     - logstash-998-filter-parsefailures.conf
 
 - name: Enable and start logstash

--- a/roles/stenographer/handlers/main.yml
+++ b/roles/stenographer/handlers/main.yml
@@ -10,10 +10,10 @@
   service:
     name: "stenographer@{{ item }}"
     state: "{{ 'started' if enable_stenographer else 'stopped' }}"
-  with_items: "{{ stenographer_monitor_interfaces }}"
+  loop: "{{ stenographer_monitor_interfaces }}"
 
 - name: Restart stenographer per interface
   service:
     name: "stenographer@{{ item }}"
     state: restarted
-  with_items: "{{ stenographer_monitor_interfaces }}"
+  loop: "{{ stenographer_monitor_interfaces }}"

--- a/roles/stenographer/tasks/config.yml
+++ b/roles/stenographer/tasks/config.yml
@@ -29,7 +29,7 @@
     mode: 0644
     owner: root
     group: root
-  with_items:
+  loop:
     - stenographer.service
     - stenographer@.service
 
@@ -51,7 +51,7 @@
   service:
     name: "stenographer@{{ item }}"
     enabled: "{{ 'True' if 'stenographer' in enabled_services else 'False' }}"
-  with_items: "{{ stenographer_monitor_interfaces }}"
+  loop: "{{ stenographer_monitor_interfaces }}"
   notify: Start stenographer per interface
 
 - name: Configure firewall ports

--- a/roles/suricata/tasks/main.yml
+++ b/roles/suricata/tasks/main.yml
@@ -6,6 +6,7 @@
     name:
       - suricata
       - filebeat
+      - PyYAML
     state: present
 
 - name: Set monitor interface config
@@ -16,7 +17,7 @@
     owner: root
     group: root
     force: yes
-  with_items: "{{ rock_monifs }}"
+  loop: "{{ rock_monifs }}"
 
 - name: Configure local ifup script
   template:
@@ -105,7 +106,7 @@
     group: "{{ suricata_group }}"
     mode: 0755
     recurse: "yes"
-  with_items:
+  loop:
     - rules
     - update
 
@@ -149,6 +150,7 @@
   command: /usr/bin/suricata-update update-sources
   args:
     creates: /var/lib/suricata/update/cache/index.yaml
+    chdir: /var/lib/suricata
   when: "'suricata_update' in enabled_services and rock_online_install"
   become: yes
   become_user: "{{ suricata_user }}"
@@ -157,6 +159,7 @@
   command: /usr/bin/suricata-update enable-source et/open
   args:
     creates: /var/lib/suricata/update/sources/et-open.yaml
+    chdir: /var/lib/suricata
   when: "'suricata_update' in enabled_services and rock_online_install"
   become: yes
   become_user: "{{ suricata_user }}"
@@ -165,6 +168,7 @@
   command: /usr/bin/suricata-update update --reload-command "/usr/bin/systemctl kill -s USR2 suricata"
   args:
     creates: /var/lib/suricata/rules/suricata.rules
+    chdir: /var/lib/suricata
   when: "'suricata_update' in enabled_services and rock_online_install"
   become: yes
   become_user: "{{ suricata_user }}"


### PR DESCRIPTION
Sorry for bundling so many together, but these were all incremental changes needed to setup [molecule](https://molecule.readthedocs.io/en/latest/) for integration testing as a remote deployment host.

## Changes
- *common*: Create cache dir if doesn't exist. Only needed for logstash.
- *common*: Make GPG key trust idempotent for yum repodata
- *common*: Fix #380 by using `ini_file` module instead of `yum_repository` and adding CentOS distro check
- *bro*: Related to #343, fixed another edge case where bro would fail if interface was down when trying to start
- *bro*: Ensure `reload bro` handler runs after interfaces script
- *elasticsearch*: Changed Elasticsearch wait to use Elasticsearch API on the `es_url` endpoint, allowing both local and remote lookups
- *elasticsearch*: Fixed bug in config template to compare size of elasticsearch group vs the list itself
- *suricata*: Add PyYAML to explicit package list
- *suricata*: Ensure `suricata-update` is always run in `/var/lib/suricata`