### PR TITLE
Revert "Update pyopenssl tasks for simplicity and to fix type casting"

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -80,6 +80,7 @@ rocknsm_package_list:
   - tmux
   - nmap-ncat
   - logrotate
+  - python-pyOpenSSL
   - firewalld
   - chrony
   - libselinux-python

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -205,9 +205,6 @@
   - { name: updates, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra" }
   - { name: extras, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra"}
 
-# We need to make sure pyopenssl >= 0.15 is installed to support the following module
-# https://docs.ansible.com/ansible/latest/modules/openssl_certificate_module.html#openssl-certificate-module
-# The "base" repo only goes up to 0.13, so we need to exclude it for this task
 - name: Install pyopenssl package
   yum:
     name: python-pyOpenSSL

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -205,13 +205,6 @@
   - { name: updates, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra" }
   - { name: extras, mirror: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra"}
 
-- name: Install pyopenssl package
-  yum:
-    name: python-pyOpenSSL
-    disablerepo: base
-    state: installed
-  when: "'docket' in group_names or 'stenographer' in group_names"
-
 - name: Install core packages
   yum:
     name: "{{ rocknsm_package_list }}"

--- a/roles/docket/tasks/prereqs.yml
+++ b/roles/docket/tasks/prereqs.yml
@@ -8,3 +8,14 @@
       - "{{ ('docket' in groups) and (groups['docket'] | length) > 0 }}"
       - "{{ ('stenographer' in groups) and (groups['stenographer'] | length) > 0 }}"
     msg: "The [docket] and [stenographer] inventory groups must each have at least one host."
+
+- name: Check docket and stenographer hosts for pyopenssl
+  yum:
+    list=*pyOpenSSL
+  register: pyopenssl_status
+
+- name: Validate pyopenssl >= 15.0 is installed
+  assert:
+    that:
+      - "{{pyopenssl_status.results|selectattr('yumstate', 'match', 'installed')|map(attribute='version') is version_compare('15.0.0', '>=' )}}"
+    msg: "Docket hosts require PyOpenSSL greater than 15.0 prior to executing this play"


### PR DESCRIPTION
Reverts rocknsm/rock#388

python2-pyOpenSSL requires python-cryptography >= 1.3.0, which is found in Base, making this fix broken.