### PR TITLE
Change package name to python2-pyOpenSSL

### DIFF
--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -210,8 +210,7 @@
 # The "base" repo only goes up to 0.13, so we need to exclude it for this task
 - name: Install pyopenssl package
   yum:
-    name: python-pyOpenSSL
-    disablerepo: base
+    name: python2-pyOpenSSL
     state: installed
   when: "'docket' in group_names or 'stenographer' in group_names"
 


### PR DESCRIPTION
Related to #388, this fixes it so that it can be installed using the package name used in the RockNSM RPM repos and the newer EPEL convention