### PR TITLE
correct whiptail interface setup issue

### DIFF
--- a/bin/rock_setup
+++ b/bin/rock_setup
@@ -316,7 +316,7 @@ set_hostname(){
   echo "Setting hostname to ${sensor_hostname}." | logit info
   current_name=$(crudini --get /etc/rocknsm/hosts.ini rock | awk '{print $1}')
   sed -i "s/${current_name}/${sensor_hostname}/g" /etc/rocknsm/hosts.ini
-  whiptail --title "ROCK Installer :: Set Hostname" --msgbox "Hostnamme set to ${sensor_hostname}." 10 78 3>&1 1>&2 2>&3
+  whiptail --title "ROCK Installer :: Set Hostname" --msgbox "Hostname set to ${sensor_hostname}." 10 78 3>&1 1>&2 2>&3
 }
 
 set_online(){

--- a/bin/rock_setup
+++ b/bin/rock_setup
@@ -285,8 +285,8 @@ set_dhcp(){
 set_addressing(){
   # Whiptail menu to select DHCP or Static
   ip_style=$(whiptail --title "ROCK Installer :: Management IP Address" --menu "How would you like to set your management IP?" 20 78 4 \
-  "DHCP"\t"Use DHCP for management interface" \
-  "STATIC"\t"Use Static IP for management interface" \
+  "DHCP"    "Use DHCP for management interface" \
+  "STATIC"  "Use Static IP for management interface" \
   3>&1 1>&2 2>&3
   )
   #echo ${ip_style}


### PR DESCRIPTION
The last commit to this file added `\t` characters when prompting to use static or dhcp for mgmt interface.  This causes TUI to display all choices in one line.  I've tested locally and the issue is resolved when changing out to spaces.

![Screen Shot 2019-04-04 at 09 53 35](https://user-images.githubusercontent.com/17996682/55566379-2fac2b00-56c1-11e9-8feb-196032cd58c3.png)