### PR TITLE
Match new Elastic 7 changes

### DIFF
--- a/roles/elasticsearch/templates/es-jvm.options.j2
+++ b/roles/elasticsearch/templates/es-jvm.options.j2
@@ -64,7 +64,7 @@
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 
--Djava.io.tmpdir=${ES_TMPDIR}
+-Djava.io.tmpdir="${ES_TMPDIR}"
 
 ## heap dumps
 

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -1,3 +1,3 @@
 server.port: {{ kibana_port }}
 server.name: "{{ ansible_hostname }}"
-elasticsearch.url: "{{ es_url }}"
+elasticsearch.hosts: "{{ es_url }}"


### PR DESCRIPTION
Var requires quotes in jvm.option template.
Kibana changed from url to hosts.