### PR TITLE
Update roles and tests to Java 11

### DIFF
--- a/roles/docket/tasks/docket_config.yml
+++ b/roles/docket/tasks/docket_config.yml
@@ -1,8 +1,6 @@
 ---
 - name: Check existing secret_key
-  shell: >
-    set -o pipefail
-    cat /etc/docket/prod.yaml | awk '/^SECRET_KEY/ {print $2}'
+  shell: awk '/^SECRET_KEY/ {print $2}' /etc/docket/prod.yaml
   register: docket_prod
   changed_when: false
 

--- a/roles/elasticsearch/tasks/before.yml
+++ b/roles/elasticsearch/tasks/before.yml
@@ -3,7 +3,7 @@
 - name: Install packages
   yum:
     name:
-      - java-1.8.0-openjdk-headless
+      - java-11-openjdk-headless
       - elasticsearch
     state: installed
   register: es_install

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -4,6 +4,7 @@
     name:
       - kafka
       - kafkacat
+      - java-11-openjdk-headless
     state: present
 
 - name: Create kafka data directory

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Install packages
   yum:
     name:
-      - java-1.8.0-openjdk-headless
+      - java-11-openjdk-headless
       - logstash
     state: present
 

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install zookeeper packages
   yum:
     name:
-      - java-1.8.0-headless
+      - java-11-openjdk-headless
       - zookeeper
     state: installed
 

--- a/tests/vars/elasticsearch.vars
+++ b/tests/vars/elasticsearch.vars
@@ -14,7 +14,7 @@ dir_paths:
   - /etc/systemd/system/elasticsearch.service.d
 
 packages:
-  - java-1.8.0-openjdk-headless
+  - java-11-openjdk-headless
   - elasticsearch
 
 listening_ports:

--- a/tests/vars/kafka.vars
+++ b/tests/vars/kafka.vars
@@ -10,10 +10,9 @@ dir_paths:
   - /data/kafka
 
 packages:
-  - java-1.8.0-openjdk-headless
+  - java-11-openjdk-headless
   - kafka
   - kafkacat
 
 listening_ports:
   - 9092
-

--- a/tests/vars/logstash.vars
+++ b/tests/vars/logstash.vars
@@ -21,3 +21,4 @@ dir_paths:
 
 packages:
   - logstash
+  - java-11-openjdk-headless

--- a/tests/vars/zookeeper.vars
+++ b/tests/vars/zookeeper.vars
@@ -11,7 +11,7 @@ dir_paths:
   - /var/log/zookeeper
 
 packages:
-  - java-1.8.0-openjdk-headless
+  - java-11-openjdk-headless
   - zookeeper
 
 listening_ports:


### PR DESCRIPTION
This pull request changes Java to version 11 across both tests and the ansible roles. 

The second portion is to fixes #417. Ansible is executing the set -o pipefail in line with the command which returns nothing. This is what Ansible then registers and why it is writing a blank password into the prod.yml. My proposal is to remove cat and the pipe which would no longer require the pipefail.

