### PR TITLE
Change elastic node name to the inventory hostname

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -3,7 +3,7 @@ es_user: elasticsearch
 es_group: elasticsearch
 es_data_dir: "{{ rock_data_dir }}/elasticsearch"
 es_cluster_name: rocknsm
-es_node_name: "{{ ansible_hostname }}"
+es_node_name: "{{ inventory_hostname }}"
 es_network_host: >-
   {%- if (groups['elasticsearch']|union(groups['logstash'])|union(groups['kibana']))| count > 1 -%}
   _site:ipv4_


### PR DESCRIPTION
Addresses the issue in #447 by changing the node name to the inventory hostname, which is what we use to generate the initial cluster nodes for the config. This is in line with the latest Elastic documentation for [bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-bootstrap-cluster.html).