### PR TITLE
Removing become from docket tasks

### DIFF
--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -238,7 +238,7 @@
   yum:
     name: python2-pyOpenSSL
     state: installed
-  when: "'docket' in group_names or 'stenographer' in group_names"
+  when: "'docket' in group_names or 'stenographer' in group_names or 'kibana' in group_names"
 
 - name: Install core packages
   yum:

--- a/roles/docket/tasks/crypto.yml
+++ b/roles/docket/tasks/crypto.yml
@@ -13,6 +13,7 @@
   register: cachedir
   run_once: true
   delegate_to: localhost
+  become: false
 
 - name: Set ansible_cache fact
   set_fact:
@@ -180,3 +181,4 @@
   changed_when: false
   run_once: true
   delegate_to: localhost
+  become: false


### PR DESCRIPTION
No need to 'become' when checking or removing temp directories.  They get created as the current user and 'become' fails when localhost sudo password is different than remote host.