### PR TITLE
Moving task to create credentials into lighttpd role

### DIFF
--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -59,18 +59,6 @@
     owner: root
     group: root
 
-- name: Set initial kibana credentials
-  shell: |
-    set -o pipefail
-    export kibuser=$(getent passwd 1000 | awk -F: '{print $1}') && \
-    export kibpw=$(xkcdpass -a rock) && \
-    echo -e "U: ${kibuser}\nP: ${kibpw}" > /home/${kibuser}/KIBANA_CREDS.README && \
-    printf "${kibuser}:$(echo ${kibpw} | openssl passwd -apr1 -stdin)\n" | \
-    sudo tee -a /etc/lighttpd/rock-htpasswd.user > /dev/null 2>&1
-  args:
-    creates: /etc/lighttpd/rock-htpasswd.user
-  when: "'lighttpd' in installed_services"
-
 - name: Download RockNSM elastic configs
   get_url:
     url: "{{ rock_dashboards_url }}"

--- a/roles/lighttpd/tasks/add-user.yml
+++ b/roles/lighttpd/tasks/add-user.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Ensure passwd file exists
+  file:
+    path: /etc/lighttpd/rock-htpasswd.user
+    state: touch
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Hash password
+  command: "openssl passwd -apr1 \"{{ lighttpd_password }}\""
+  register: lighttpd_hashed_password
+  no_log: yes
+
+- name: Add a new user to lighttpd
+  lineinfile:
+    path: /etc/lighttpd/rock-htpasswd.user
+    regex: "^{{ lighttpd_user }}"
+    line: "{{ lighttpd_user }}:{{ lighttpd_hashed_password.stdout }}"

--- a/roles/lighttpd/tasks/add-user.yml
+++ b/roles/lighttpd/tasks/add-user.yml
@@ -11,7 +11,7 @@
 - name: Hash password
   command: "openssl passwd -apr1 \"{{ lighttpd_password }}\""
   register: lighttpd_hashed_password
-  no_log: yes
+  no_log: true
 
 - name: Add a new user to lighttpd
   lineinfile:

--- a/roles/lighttpd/tasks/main.yml
+++ b/roles/lighttpd/tasks/main.yml
@@ -102,21 +102,21 @@
   register: rocknsm_initial_user_created
 
 - block:
-  - name: Determine initial username
-    shell: "getent passwd 1000 | awk -F: '{print $1}'"
-    register: rocknsm_initial_username
+    - name: Determine initial username
+      shell: "getent passwd 1000 | awk -F: '{print $1}'"
+      register: rocknsm_initial_username
 
-  - name: Determine initial password
-    command: "xkcdpass -a rock"
-    register: rocknsm_initial_password
+    - name: Determine initial password
+      command: "xkcdpass -a rock"
+      register: rocknsm_initial_password
 
-  - name: Set initial credentials
-    include_tasks: add-user.yml
-    vars:
-      lighttpd_user: "{{ rocknsm_initial_username.stdout }}"
-      lighttpd_password: "{{ rocknsm_initial_password.stdout }}"
+    - name: Set initial credentials
+      include_tasks: add-user.yml
+      vars:
+        lighttpd_user: "{{ rocknsm_initial_username.stdout }}"
+        lighttpd_password: "{{ rocknsm_initial_password.stdout }}"
 
-  - name: Output initial credentials
-    shell: "echo -e \"U: {{ rocknsm_initial_username.stdout }}\nP: {{ rocknsm_initial_password.stdout }}\" 
-            > /home/{{ rocknsm_initial_username.stdout }}/KIBANA_CREDS.README"
+    - name: Output initial credentials
+      shell: "echo -e \"U: {{ rocknsm_initial_username.stdout }}\nP: {{ rocknsm_initial_password.stdout }}\"
+              > /home/{{ rocknsm_initial_username.stdout }}/KIBANA_CREDS.README"
   when: rocknsm_initial_user_created.stat.exists == False

--- a/roles/lighttpd/tasks/main.yml
+++ b/roles/lighttpd/tasks/main.yml
@@ -95,3 +95,14 @@
     immediate: true
   loop:
     - 443
+
+- name: Set initial credentials
+  shell: |
+    set -o pipefail
+    export kibuser=$(getent passwd 1000 | awk -F: '{print $1}') && \
+    export kibpw=$(xkcdpass -a rock) && \
+    echo -e "U: ${kibuser}\nP: ${kibpw}" > /home/${kibuser}/KIBANA_CREDS.README && \
+    printf "${kibuser}:$(echo ${kibpw} | openssl passwd -apr1 -stdin)\n" | \
+    sudo tee -a /etc/lighttpd/rock-htpasswd.user > /dev/null 2>&1
+  args:
+    creates: /etc/lighttpd/rock-htpasswd.user

--- a/roles/lighttpd/tasks/main.yml
+++ b/roles/lighttpd/tasks/main.yml
@@ -96,13 +96,27 @@
   loop:
     - 443
 
-- name: Set initial credentials
-  shell: |
-    set -o pipefail
-    export kibuser=$(getent passwd 1000 | awk -F: '{print $1}') && \
-    export kibpw=$(xkcdpass -a rock) && \
-    echo -e "U: ${kibuser}\nP: ${kibpw}" > /home/${kibuser}/KIBANA_CREDS.README && \
-    printf "${kibuser}:$(echo ${kibpw} | openssl passwd -apr1 -stdin)\n" | \
-    sudo tee -a /etc/lighttpd/rock-htpasswd.user > /dev/null 2>&1
-  args:
-    creates: /etc/lighttpd/rock-htpasswd.user
+- name: Check if initial user has already been created
+  stat:
+    path: /etc/lighttpd/rock-htpasswd.user
+  register: rocknsm_initial_user_created
+
+- block:
+  - name: Determine initial username
+    shell: "getent passwd 1000 | awk -F: '{print $1}'"
+    register: rocknsm_initial_username
+
+  - name: Determine initial password
+    command: "xkcdpass -a rock"
+    register: rocknsm_initial_password
+
+  - name: Set initial credentials
+    include_tasks: add-user.yml
+    vars:
+      lighttpd_user: "{{ rocknsm_initial_username.stdout }}"
+      lighttpd_password: "{{ rocknsm_initial_password.stdout }}"
+
+  - name: Output initial credentials
+    shell: "echo -e \"U: {{ rocknsm_initial_username.stdout }}\nP: {{ rocknsm_initial_password.stdout }}\" 
+            > /home/{{ rocknsm_initial_username.stdout }}/KIBANA_CREDS.README"
+  when: rocknsm_initial_user_created.stat.exists == False

--- a/roles/lighttpd/tasks/remove-user.yml
+++ b/roles/lighttpd/tasks/remove-user.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Remove a user from lighttpd
+  lineinfile:
+    path: /etc/lighttpd/rock-htpasswd.user
+    regex: "^{{ lighttpd_user }}"
+    state: absent


### PR DESCRIPTION
When docket and kibana are on different servers, the credentials for lighttpd are not generated to access the docket instance.  By moving that functionality into the lighttpd role, you achieve the expected behavior.