### PR TITLE
Fix service enable logic and other cleanup

### DIFF
--- a/playbooks/deploy-rock.yml
+++ b/playbooks/deploy-rock.yml
@@ -155,7 +155,7 @@
   roles:
     - role: docket
       when: "rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='installed')"
-      docket_enable: "{{ (rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool }}"
+      docket_enable: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
 
 - hosts: kibana
   tags:

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -79,6 +79,10 @@ rock_services:
     quota_weight: 0
     installed: true
     enabled: true
+  - name: logstash
+    quota_weight: 0
+    installed: true
+    enabled: true
 
 rocknsm_package_list:
   - jq

--- a/roles/bro/handlers/main.yml
+++ b/roles/bro/handlers/main.yml
@@ -10,4 +10,5 @@
 - name: Reload bro
   service:
     name: bro
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'bro') | map(attribute='enabled') | bool else 'stopped' }}"
+    state: restarted
+  when: local_services | selectattr('name', 'equalto', 'bro') | map(attribute='enabled') | first | bool

--- a/roles/bro/tasks/main.yml
+++ b/roles/bro/tasks/main.yml
@@ -339,8 +339,7 @@
 - name: Enable and start bro
   service:
     name: bro
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'bro') | map(attribute='enabled') | bool else 'stopped' }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'bro') | map(attribute='enabled') | bool }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'bro') | map(attribute='enabled') | first | bool }}"
   notify: Reload bro
 
 - name: Apply Logstash role

--- a/roles/common/tasks/deploy.yml
+++ b/roles/common/tasks/deploy.yml
@@ -1,5 +1,6 @@
 ---
 # deploy.yml - Common tasks for ROCK
+- import_tasks: gather-facts.yml
 - import_tasks: configure.yml
 - import_tasks: configure-time.yml
 - import_tasks: configure-pipelining.yml

--- a/roles/common/tasks/gather-facts.yml
+++ b/roles/common/tasks/gather-facts.yml
@@ -1,5 +1,5 @@
 ---
 # Set local system-specific facts
 - set_fact:
-    local_services: "{{ rock_services | selectattr("name", "in", groups.keys()) | list }}"
+    local_services: "{{ rock_services | selectattr('name', 'in', groups.keys()) | list }}"
 ...

--- a/roles/common/tasks/gather-facts.yml
+++ b/roles/common/tasks/gather-facts.yml
@@ -1,5 +1,6 @@
 ---
 # Set local system-specific facts
-- set_fact:
+- name: Gather local service facts specific to each host
+  set_fact:
     local_services: "{{ rock_services | selectattr('name', 'in', groups.keys()) | list }}"
 ...

--- a/roles/common/tasks/gather-facts.yml
+++ b/roles/common/tasks/gather-facts.yml
@@ -1,0 +1,5 @@
+---
+# Set local system-specific facts
+- set_fact:
+    local_services: "{{ rock_services | selectattr("name", "in", groups.keys()) | list }}"
+...

--- a/roles/docket/handlers/main.yml
+++ b/roles/docket/handlers/main.yml
@@ -17,7 +17,7 @@
   service:
     name: redis
     state: restarted
-  when: rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool
+  when: local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool
 
 - name: Seed random key
   lineinfile:
@@ -33,16 +33,16 @@
   loop:
     - docket-celery-io
     - docket-celery-query
-  when: rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool
+  when: local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool
 
 - name: Restart docket uwsgi
   service:
     name: docket
     state: restarted
-  when: rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool
+  when: local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool
 
 - name: Restart lighttpd
   service:
     name: lighttpd
     state: restarted
-  when: rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool
+  when: local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool

--- a/roles/docket/tasks/docket_config.yml
+++ b/roles/docket/tasks/docket_config.yml
@@ -30,12 +30,12 @@
     name: redis
     enabled: true
   notify: Restart redis
-  when: "rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') "
+  when: "local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool"
 
 - name: Enable docket celery services
   service:
     name: "{{ item }}"
-    enabled: "{{ 'True' if rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool else 'False' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
   notify: Restart docket celery services
   loop:
     - docket-celery-io
@@ -44,5 +44,5 @@
 - name: Enable docket uwsgi service
   service:
     name: docket
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
   notify: Restart docket uwsgi

--- a/roles/docket/tasks/lighttpd.yml
+++ b/roles/docket/tasks/lighttpd.yml
@@ -41,5 +41,5 @@
 - name: Enable lighttpd service
   service:
     name: lighttpd
-    enabled: {{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
   notify: Restart lighttpd

--- a/roles/docket/tasks/lighttpd.yml
+++ b/roles/docket/tasks/lighttpd.yml
@@ -41,5 +41,5 @@
 - name: Enable lighttpd service
   service:
     name: lighttpd
-    enabled: true
+    enabled: {{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}
   notify: Restart lighttpd

--- a/roles/elasticsearch/tasks/before.yml
+++ b/roles/elasticsearch/tasks/before.yml
@@ -123,8 +123,8 @@
 - name: Enable and start elasticsearch
   service:
     name: elasticsearch
-    state: "started"
-    enabled: "{{ 'true' if rock_services | selectattr('name', 'equalto', 'elasticsearch') | map(attribute='enabled') | bool else 'false' }}"
+    state: started
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'elasticsearch') | map(attribute='enabled') | first | bool }}"
 
 - name: Create internal firewall zone
   firewalld:

--- a/roles/filebeat/tasks/main.yml
+++ b/roles/filebeat/tasks/main.yml
@@ -30,5 +30,5 @@
 - name: Enable and start filebeat
   service:
     name: filebeat
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'filebeat') | map(attribute='enabled') | bool else 'stopped' }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'filebeat') | map(attribute='enabled') | bool }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'filebeat') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'filebeat') | map(attribute='enabled') | first | bool }}"

--- a/roles/fsf/tasks/main.yml
+++ b/roles/fsf/tasks/main.yml
@@ -109,8 +109,8 @@
 - name: Enable and start FSF
   service:
     name: fsf
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'fsf') | map(attribute='enabled') | bool else 'stopped' }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'fsf') | map(attribute='enabled') | bool }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'fsf') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'fsf') | map(attribute='enabled') | first | bool }}"
 
 - name: Apply Logstash role
   include_role:

--- a/roles/fsf/tasks/main.yml
+++ b/roles/fsf/tasks/main.yml
@@ -119,7 +119,7 @@
       delegate_to: "{{ host }}"
       vars:
         logstash_configs:
-          - { src: 'ls-input-fsf.j2', dest: '100-input-fsf.conf' }
+          - { src: 'ls-input-fsf.j2', dest: 'logstash-100-input-kafka-fsf.conf' }
   loop:
     "{{ groups['logstash'] }}"
   loop_control:

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for kafka
+kafka_zookeeper_host: 127.0.0.1
+kafka_zookeeper_port: 2181

--- a/roles/kafka/files/wait-for-zookeeper.py
+++ b/roles/kafka/files/wait-for-zookeeper.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+
+import socket
+import os
+import sys
+import logging
+
+# Byte conversion utility for compatibility between
+# Python 2 and 3.
+# http://python3porting.com/problems.html#nicer-solutions
+if sys.version_info < (3,):
+    def _b(x):
+        return x
+else:
+    import codecs
+    def _b(x):
+        return codecs.latin_1_encode(x)[0]
+
+
+class SystemdNotifier:
+    """This class holds a connection to the systemd notification socket
+    and can be used to send messages to systemd using its notify method."""
+
+    def __init__(self, debug=False):
+        """Instantiate a new notifier object. This will initiate a connection
+        to the systemd notification socket.
+        Normally this method silently ignores exceptions (for example, if the
+        systemd notification socket is not available) to allow applications to
+        function on non-systemd based systems. However, setting debug=True will
+        cause this method to raise any exceptions generated to the caller, to
+        aid in debugging.
+        """
+        self.debug = debug
+        try:
+            self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            addr = os.getenv('NOTIFY_SOCKET')
+            if addr[0] == '@':
+                addr = '\0' + addr[1:]
+            self.socket.connect(addr)
+        except:
+            self.socket = None
+            if self.debug:
+                raise
+
+    def notify(self, state):
+        """Send a notification to systemd. state is a string; see
+        the man page of sd_notify (http://www.freedesktop.org/software/systemd/man/sd_notify.html)
+        for a description of the allowable values.
+        Normally this method silently ignores exceptions (for example, if the
+        systemd notification socket is not available) to allow applications to
+        function on non-systemd based systems. However, setting debug=True will
+        cause this method to raise any exceptions generated to the caller, to
+        aid in debugging."""
+        try:
+            self.socket.sendall(_b(state))
+        except:
+            if self.debug:
+                raise
+
+
+def main(argv):
+    import getopt
+    timeout = 30
+    try:
+        opts, args = getopt.getopt(argv[1:],"t",["timeout="])
+    except getopt.GetoptError:
+        print ('{} [-t|--timeout 10] zookeeper:2181'.format(argv[0]) )
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt in ("-t", "--timeout"):
+            timeout = arg
+            logging.info("Setting timeout to {} seconds".format(timeout))
+
+    if len(args) == 0:
+        print ('ERROR: Zookeeper host and port are required.')
+        sys.exit(3)
+
+
+    host, separator, port = args[0].rpartition(':')
+
+    assert separator # separator (`:`) must be present
+    port = int(port) # convert to integer
+
+    n = SystemdNotifier()
+    n.notify("STATUS=Connecting to Zookeeper at {}:{}".format(host, port))
+    zk_sock = None
+    while True:
+      try:
+          zk_sock = socket.create_connection((host, port), timeout)
+          break
+      except socket.error:
+          logging.error("Connection refused. Trying again...")
+      except socket.timeout:
+          logging.error("Timeout expired. Trying again...")
+
+    # We're connected. Let's ask zookeeper if it's ready
+    zk_sock.send("ruok\n")
+    zk_resp = zk_sock.recv(1024)
+    if zk_resp != "imok":
+        logging.error("Zookeeper up but not healthy: {}".format(zk_resp))
+        # 121 == EREMOTEIO
+        n.notify("ERRNO=121")
+        exit(121)
+
+    n.notify("STATUS=Zookeeper is ready at {}:{}!".format(host, port))
+    n.notify("READY=1")
+
+    exit(0)
+
+if __name__ == '__main__':
+   import sys
+   main(sys.argv)

--- a/roles/kafka/files/wait-for-zookeeper.service
+++ b/roles/kafka/files/wait-for-zookeeper.service
@@ -1,0 +1,21 @@
+# /etc/systemd/system/wait-for-zookeeper.service
+[Unit]
+Description=Wait For Zookeeper Service
+Before=kafka.service
+After=network.target
+After=zookeeper.service
+Wants=zookeeper.service
+
+[Service]
+Type=notify
+NotifyAccess=all
+WorkingDirectory=/tmp
+Environment=ZOOKEEPER_HOST=127.0.0.1
+Environment=ZOOKEEPER_PORT=2181
+EnvironmentFile=-/etc/sysconfig/wait-for-zookeeper
+ExecStart=/usr/local/sbin/wait-for-zookeeper.py ${ZOOKEEPER_HOST}:${ZOOKEEPER_PORT}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+RequiredBy=kafka.service

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -87,11 +87,63 @@
     mountpoint: "{{ rock_mounts.mount }}"
   when: rock_mounts is defined and (prjquota.stdout|length>0)
 
+- name: Create wait-for-zookeeper sidecar
+  copy:
+    dest: "{{ item.dest }}"
+    src: "{{ item.src }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  with_items:
+    - src: wait-for-zookeeper.py
+      dest: /usr/local/sbin/wait-for-zookeeper.py
+      mode: '0755'
+    - src: wait-for-zookeeper.service
+      dest: /etc/systemd/system/wait-for-zookeeper.service
+      mode: '0644'
+  register: wait_for_zk_created
+
+- name: Create environment file for sidecar
+  copy:
+    dest: /etc/sysconfig/wait-for-zookeeper
+    content: |
+      ZOOKEEPER_HOST={{ kafka_zookeeper_host }}
+      ZOOKEEPER_PORT={{ kafka_zookeeper_port }}
+    mode: '0644'
+    owner: root
+    group: root
+
+- name: Create kafka service overrides dir
+  file:
+    state: directory
+    path: /etc/systemd/system/kafka.service.d/
+    recurse: yes
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Insert Kafka override to wait for Zookeeper
+  copy:
+    dest: /etc/systemd/system/kafka.service.d/override.conf
+    content: |
+      # /etc/systemd/system/kafka.service.d/override.conf
+      [Unit]
+      After=wait-for-zookeeper.service
+      Requires=wait-for-zookeeper.service
+    mode: '0644'
+    owner: root
+    group: root
+  register: kafka_override_created
+
 - name: Enable and start kafka
   service:
-    name: kafka
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'kafka') | map(attribute='enabled') | bool else 'stopped' }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'kafka') | map(attribute='enabled') | bool }}"
+    name: "{{ item }}"
+    daemon-reload: kafka_override_created.changed or wait_for_zk_created.changed
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'kafka') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'kafka') | map(attribute='enabled') | first | bool }}"
+  with_items:
+    - wait-for-zookeeper
+    - kafka
 
 - name: Configure firewall ports
   firewalld:

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -138,7 +138,7 @@
 - name: Enable and start kafka
   service:
     name: "{{ item }}"
-    daemon-reload: kafka_override_created.changed or wait_for_zk_created.changed
+    daemon-reload: "{{ kafka_override_created.changed or wait_for_zk_created.changed }}"
     state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'kafka') | map(attribute='enabled') | first | bool else 'stopped' }}"
     enabled: "{{ local_services | selectattr('name', 'equalto', 'kafka') | map(attribute='enabled') | first | bool }}"
   with_items:

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -117,7 +117,7 @@
   file:
     state: directory
     path: /etc/systemd/system/kafka.service.d/
-    recurse: yes
+    recurse: true
     owner: root
     group: root
     mode: '0755'

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -24,6 +24,7 @@
   uri:
     url: "{{ kibana_url }}/api/kibana/settings"
     status_code: 200
+    return_content: true
   register: result
   until: result.status == 200
   retries: 60
@@ -50,6 +51,27 @@
         "mappings" : { }, "aliases" : { } }
     body_format: json
     status_code: 200,201
+
+- name: Configure SIEM to read ecs-* index pattern
+  uri:
+    method: POST
+    url: "{{ kibana_url }}/api/kibana/settings:siem"
+    body: >
+      {"changes": {
+         "siem:defaultIndex": [
+            "auditbeat-*",
+            "filebeat-*",
+            "packetbeat-*",
+            "winlogbeat-*",
+            "ecs-*"
+          ]
+        }
+      }
+    headers:
+      kbn-version: 7.4.0
+    body_format: json
+    status_code: 200,201
+    when: "'ecs-*' not in result.content"
 
 - name: Add the kibanapw shell function
   copy:

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -17,8 +17,8 @@
 - name: Enable and start kibana
   service:
     name: kibana
-    state: "started"
-    enabled: "{{ 'True' if rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='enabled') | bool else 'False' }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='enabled') | first | bool }}"
 
 - name: "Wait for Kibana to be available"
   uri:

--- a/roles/lighttpd/handlers/main.yml
+++ b/roles/lighttpd/handlers/main.yml
@@ -3,15 +3,15 @@
   systemd:
     name: lighttpd
     state: >-
-      {%- if rock_services | selectattr('name', 'equalto', 'lighttpd') | map(attribute='enabled') or
-      rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') -%}
+      {%- if local_services | selectattr('name', 'equalto', 'lighttpd') | map(attribute='enabled') | first | bool or
+      local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool -%}
         restarted
       {%- else -%}
         stopped
       {%- endif -%}
     enabled: >-
-      {%- if rock_services | selectattr('name', 'equalto', 'lighttpd') | map(attribute='enabled') or
-      rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') -%}
+      {%- if local_services | selectattr('name', 'equalto', 'lighttpd') | map(attribute='enabled') | first | bool or
+      local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool -%}
         True
       {%- else -%}
         False

--- a/roles/lighttpd/tasks/main.yml
+++ b/roles/lighttpd/tasks/main.yml
@@ -14,7 +14,7 @@
     mode: 0644
     owner: root
     group: root
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
   loop:
     - 10-rock-auth.conf
     - 10-tls.conf
@@ -41,19 +41,19 @@
     name: httpd_can_network_connect
     state: true
     persistent: true
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
 
 - name: Generate sensor private key
   openssl_privatekey:
     path: "{{ http_tls_key }}"
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
   notify: Enable and restart lighttpd
 
 - name: Generate sensor public key
   openssl_publickey:
     path: "{{ http_tls_pub }}"
     privatekey_path: "{{ http_tls_key }}"
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
   notify: Enable and restart lighttpd
 
 - name: Generate sensor CSR
@@ -67,7 +67,7 @@
     organizational_unit_name: NSM Ninjas
     email_address: info@rocknsm.io
     common_name: "{{ ansible_hostname }}"
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
   notify: Enable and restart lighttpd
 
 - name: Generate sensor certificate
@@ -76,7 +76,7 @@
     privatekey_path: "{{ http_tls_key }}"
     csr_path: "{{ http_tls_pub }}.csr"
     provider: selfsigned
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
   notify: Enable and restart lighttpd
 
 - name: Combine sensor cert and key
@@ -91,7 +91,7 @@
     openssl dhparam -out {{ http_tls_dhparams }} 2048
   args:
     creates: "{{ http_tls_dhparams }}"
-  when: "rock_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed')"
+  when: "local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='installed') | first | bool"
   notify: Enable and restart lighttpd
 
 - name: Configure firewall ports

--- a/roles/logstash/handlers/main.yml
+++ b/roles/logstash/handlers/main.yml
@@ -3,4 +3,4 @@
 - name: Restart logstash
   systemd:
     name: logstash
-    state: restarted
+    state: "{{ 'restarted' if local_services | selectattr('name', 'equalto', 'logstash') | map(attribute='enabled') | first | bool else 'stopped' }}"

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -20,6 +20,7 @@
     dest: "/etc/logstash/conf.d/"
     owner: "{{ logstash_user }}"
     group: "{{ logstash_group }}"
+  notify: Restart logstash
 
 - name: Copy Logstash ruby scripts to /etc
   copy:
@@ -28,6 +29,7 @@
     dest: "/etc/logstash/conf.d/ruby"
     owner: "{{ logstash_user }}"
     group: "{{ logstash_group }}"
+  notify: Restart logstash
 
 - name: Template input configs
   template:
@@ -56,6 +58,7 @@
     path: /etc/logstash/logstash.yml
     line: "xpack.monitoring.enabled: true"
     regexp: '^#xpack.monitoring.enabled: .*'
+  notify: Restart logstash
 
 - name: Point logstash monitoring to elastic hosts
   lineinfile:
@@ -71,9 +74,10 @@
           ["127.0.0.1:9200"]
           {%- endif %}
     regexp: '^#xpack.monitoring.elasticsearch.hosts: .*'
+  notify: Restart logstash
 
 - name: Enable and start Logstash
   service:
     name: logstash
-    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'logstash') | map(attribute='enabled') | first | bool else 'stopped' }}"
     enabled: "{{ local_services | selectattr('name', 'equalto', 'logstash') | map(attribute='enabled') | first | bool }}"
+  notify: Restart logstash

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -21,6 +21,13 @@
     owner: "{{ logstash_user }}"
     group: "{{ logstash_group }}"
 
+- name: Copy Logstash ruby scripts to /etc
+  copy:
+    remote_src: true
+    src: "{{ rock_module_dir }}/ecs-configuration/logstash/ruby/"
+    dest: "/etc/logstash/conf.d/ruby"
+    owner: "{{ logstash_user }}"
+    group: "{{ logstash_group }}"
 
 - name: Template input configs
   template:
@@ -36,7 +43,7 @@
 - name: Template Elasticsearch output for Logstash
   template:
     src: "{{ item }}.j2"
-    dest: "/etc/logstash/conf.d/{{ item }}.conf"
+    dest: "/etc/logstash/conf.d/{{ item }}"
     owner: "{{ logstash_user }}"
     group: "{{ logstash_group }}"
     mode: 0640

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -47,5 +47,5 @@
 - name: Enable and start Logstash
   service:
     name: logstash
-    state: "started"
-    enabled: "{{ 'True' if rock_services | selectattr('name', 'equalto', 'logstash') | map(attribute='enabled') | bool else 'False' }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'logstash') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'logstash') | map(attribute='enabled') | first | bool }}"

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -51,6 +51,27 @@
   loop:
     - logstash-9999-output-elasticsearch.conf
 
+- name: Enable logstash monitoring
+  lineinfile:
+    path: /etc/logstash/logstash.yml
+    line: "xpack.monitoring.enabled: true"
+    regexp: '^#xpack.monitoring.enabled: .*'
+
+- name: Point logstash monitoring to elastic hosts
+  lineinfile:
+    path: /etc/logstash/logstash.yml
+    line: >
+          xpack.monitoring.elasticsearch.hosts:
+          {% if groups['elasticsearch'] | length > 1 -%}[
+            {%- for host in groups['es_data'] -%}
+              "{{ host }}"
+              {%- if not loop.last %},{% endif -%}
+            {%- endfor -%}]
+          {% else %}
+          ["127.0.0.1:9200"]
+          {%- endif %}
+    regexp: '^#xpack.monitoring.elasticsearch.hosts: .*'
+
 - name: Enable and start Logstash
   service:
     name: logstash

--- a/roles/stenographer/handlers/main.yml
+++ b/roles/stenographer/handlers/main.yml
@@ -4,16 +4,16 @@
 - name: Start stenographer service
   service:
     name: stenographer
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | bool else 'stopped' }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | first | bool else 'stopped' }}"
 
 - name: Start stenographer per interface
   service:
     name: "stenographer@{{ item }}"
-    state: "{{ 'started' if enable_stenographer else 'stopped' }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | first | bool else 'stopped' }}"
   loop: "{{ stenographer_monitor_interfaces }}"
 
 - name: Restart stenographer per interface
   service:
     name: "stenographer@{{ item }}"
-    state: restarted
+    state: "{{ 'restarted' if local_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | first | bool else 'stopped' }}"
   loop: "{{ stenographer_monitor_interfaces }}"

--- a/roles/stenographer/tasks/config.yml
+++ b/roles/stenographer/tasks/config.yml
@@ -102,13 +102,13 @@
 - name: Configure stenographer service
   service:
     name: stenographer
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | bool }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | first | bool }}"
   notify: Start stenographer service
 
 - name: Configure stenographer per interface
   service:
     name: "stenographer@{{ item }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | bool }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'stenographer') | map(attribute='enabled') | first | bool }}"
   loop: "{{ stenographer_monitor_interfaces }}"
   notify: Start stenographer per interface
 

--- a/roles/suricata/tasks/main.yml
+++ b/roles/suricata/tasks/main.yml
@@ -153,8 +153,8 @@
 - name: Enable and start suricata
   service:
     name: suricata
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | bool else 'stopped' }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | bool }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool }}"
 
 - name: Configure logrotate for suricata logs
   template:
@@ -168,7 +168,7 @@
   command: /usr/bin/suricata-update add-source "emerging-threats-offline" "file:///srv/rocknsm/support/emerging.rules-suricata.tar.gz"
   args:
     creates: /var/lib/suricata/update/sources/emerging-threats-offline.yaml
-  when: "rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='installed') and not rock_online_install"
+  when: "local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='installed') | first | bool and not rock_online_install"
   become: true
   become_user: "{{ suricata_user }}"
 
@@ -176,7 +176,7 @@
   command: /usr/bin/suricata-update update --reload-command "/usr/bin/systemctl kill -s USR2 suricata"
   args:
     creates: /var/lib/suricata/rules/suricata.rules
-  when: "rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') and not rock_online_install"
+  when: "local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool and not rock_online_install"
   become: true
   become_user: "{{ suricata_user }}"
 
@@ -185,7 +185,7 @@
   args:
     creates: /var/lib/suricata/update/cache/index.yaml
     chdir: /var/lib/suricata
-  when: "rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') and rock_online_install"
+  when: "local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool and rock_online_install"
   become: true
   become_user: "{{ suricata_user }}"
 
@@ -194,7 +194,7 @@
   args:
     creates: /var/lib/suricata/update/sources/et-open.yaml
     chdir: /var/lib/suricata
-  when: "rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') and rock_online_install"
+  when: "local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool and rock_online_install"
   become: true
   become_user: "{{ suricata_user }}"
 
@@ -203,7 +203,7 @@
   args:
     creates: /var/lib/suricata/rules/suricata.rules
     chdir: /var/lib/suricata
-  when: "rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') and rock_online_install"
+  when: "local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool and rock_online_install"
   become: true
   become_user: "{{ suricata_user }}"
 
@@ -216,7 +216,7 @@
     minute: "0"
     job: /usr/bin/suricata-update update --reload-command "/usr/bin/systemctl kill -s USR2 suricata"
          > /var/log/suricata-update.log 2>&1
-  when: "rock_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled')"
+  when: "local_services | selectattr('name', 'equalto', 'suricata') | map(attribute='enabled') | first | bool"
 
 - name: Apply Logstash role
   include_role:

--- a/roles/zookeeper/handlers/main.yml
+++ b/roles/zookeeper/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
 # handlers file for zookeeper
+- name: Restart zookeeper
+  systemd:
+    name: zookeeper
+    state: "{{ 'restarted' if local_services | selectattr('name', 'equalto', 'zookeeper') | map(attribute='enabled') | first | bool else 'stopped' }}"

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -9,6 +9,6 @@
 - name: Enable and Start zookeeper
   systemd:
     name: zookeeper
-    state: "{{ 'started' if rock_services | selectattr('name', 'equalto', 'zookeeper') | map(attribute='enabled') | bool else 'stopped' }}"
-    enabled: "{{ rock_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | bool }}"
+    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'zookeeper') | map(attribute='enabled') | first | bool else 'stopped' }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
 ...

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -9,6 +9,6 @@
 - name: Enable and Start zookeeper
   systemd:
     name: zookeeper
-    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'zookeeper') | map(attribute='enabled') | first | bool else 'stopped' }}"
     enabled: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
+  notify: Restart zookeeper
 ...


### PR DESCRIPTION
Fixes logic for new `rock_services` to make them host specific lookups against a fact called `local_services` determined at runtime, filtered on the groups the given host is a member of.

This also includes fixes for a zookeeper/kafka race condition with a custom service that waits for zookeeper to be ready before allowing Kafka to start.

Lastly, this fixes some duplication of effort in logstash configs that was causing startup to fail in some cases.

Closes #488 