### PR TITLE
Fix ECS template mappings

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -173,6 +173,8 @@ logstash_group: logstash
 kibana_host: "127.0.0.1"
 kibana_port: "5601"
 kibana_url: "http://{{ kibana_host }}:{{ kibana_port }}"
+# Set default page to "Welcome [ROCK]" dashboard
+kibana_defaultRoute: "/app/kibana#/dashboard/6151e9d0-bf83-11e9-85bb-3b744f61312d"
 
 
 ###############################################################################

--- a/roles/elasticsearch/tasks/after.yml
+++ b/roles/elasticsearch/tasks/after.yml
@@ -38,7 +38,7 @@
 - name: Blanket install/update elasticsearch mappings
   command: ./import-index-templates.sh "{{ es_url }}"
   args:
-    chdir: "{{ rock_module_dir }}/configuration/elasticsearch"
+    chdir: "{{ rock_module_dir }}/ecs-configuration/elasticsearch"
   register: result
   changed_when: 'result.stdout.find("Changed: 0") != -1'
   run_once: true

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -43,3 +43,7 @@ action.destructive_requires_name: true
 node.master: {{ node_master }}
 node.data: {{ node_data }}
 node.ingest: {{ node_ingest }}
+
+# Enable Stack Monitoring
+xpack.monitoring.enabled: true
+xpack.monitoring.collection.enabled: true

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+kibana_defaultRoute: /app/kibana

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -11,14 +11,13 @@
     dest: /etc/kibana/kibana.yml
   notify: Restart kibana
 
-- name: Flush handlers
-  meta: flush_handlers
-
 - name: Enable and start kibana
   service:
     name: kibana
-    state: "{{ 'started' if local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='enabled') | first | bool else 'stopped' }}"
     enabled: "{{ local_services | selectattr('name', 'equalto', 'kibana') | map(attribute='enabled') | first | bool }}"
+
+- name: Flush handlers
+  meta: flush_handlers
 
 - name: "Wait for Kibana to be available"
   uri:
@@ -29,6 +28,10 @@
   until: result.status == 200
   retries: 60
   delay: 1
+
+- name: Store Kibana settings
+  set_fact:
+    kbn_settings: "{{ result.json.settings }}"
 
 - name: Blanket install/update kibana saved objects
   command: ./import-saved-items.sh "{{ kibana_url }}"
@@ -52,26 +55,54 @@
     body_format: json
     status_code: 200,201
 
-- name: Configure SIEM to read ecs-* index pattern
+- name: Set Kibana dark mode for the default space
   uri:
     method: POST
-    url: "{{ kibana_url }}/api/kibana/settings:siem"
+    url: "{{ kibana_url }}/api/kibana/settings"
     body: >
       {"changes": {
-         "siem:defaultIndex": [
-            "auditbeat-*",
-            "filebeat-*",
-            "packetbeat-*",
-            "winlogbeat-*",
-            "ecs-*"
-          ]
+         "theme:darkMode": true
         }
       }
     headers:
-      kbn-version: 7.4.0
+      kbn-xsrf: true
     body_format: json
     status_code: 200,201
-    when: "'ecs-*' not in result.content"
+  when: "'theme:darkMode' not in kbn_settings or not (kbn_settings['theme:darkMode']|bool)"
+
+- name: Set Kibana to store data in session storage
+  uri:
+    method: POST
+    url: "{{ kibana_url }}/api/kibana/settings"
+    body: >
+      {"changes": {
+         "state:storeInSessionStorage": true
+        }
+      }
+    headers:
+      kbn-xsrf: true
+    body_format: json
+    status_code: 200,201
+  when: "'state:storeInSessionStorage' not in kbn_settings or not (kbn_settings['state:storeInSessionStorage']|bool)"
+
+- name: Set fact for list of SIEM index patterns
+  set_fact:
+    siem_indices: "{{ kbn_settings['siem:defaultIndex']['userValue'] | default(['auditbeat-*', 'filebeat-*', 'packetbeat-*', 'winlogbeat-*']) }}"
+
+- name: Configure SIEM to read ecs-* index pattern
+  uri:
+    method: POST
+    url: "{{ kibana_url }}/api/kibana/settings"
+    body: >
+      {"changes": {
+         "siem:defaultIndex": {{ siem_indices | union(['ecs-*']) }}
+        }
+      }
+    headers:
+      kbn-xsrf: true
+    body_format: json
+    status_code: 200,201
+  when: "'siem:defaultIndex' not in kbn_settings or 'ecs-*' not in kbn_settings['siem:defaultIndex']['userValue']"
 
 - name: Add the kibanapw shell function
   copy:

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -1,3 +1,4 @@
 server.port: {{ kibana_port }}
 server.name: "{{ ansible_hostname }}"
+server.defaultRoute: "{{ kibana_defaultRoute }}"
 elasticsearch.hosts: "{{ es_url }}"


### PR DESCRIPTION
Elasticsearch was still loading the previous templates, which of course was breaking dashboards and things for ECS