### PR TITLE
Add Elastic version to software install

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -6,7 +6,7 @@ https_proxy: "{{ lookup('env', 'https_proxy') }}"
 rock_version: "{{ lookup('file', '/etc/rocknsm/rock-version', errors='ignore') | default('2.5.0') }}"
 elastic:
   major_version: 7
-  suffix: "x"
+  suffix: 4
 elastic_version: "{{ elastic.major_version }}.{{ elastic.suffix }}"
 rock_online_install: true
 rock_enable_testing: false

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -111,7 +111,7 @@ docket_web_dhparams: "{{ http_tls_dhparams }}"
 
 epel_baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
 epel_gpgurl: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
-elastic_baseurl: https://artifacts.elastic.co/packages/{{ elastic_version }}/yum
+elastic_baseurl: https://artifacts.elastic.co/packages/{{ elastic.major_version }}.x/yum
 elastic_gpgurl: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
 rocknsm_baseurl: https://packagecloud.io/rocknsm/2_4/el/7/$basearch

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -123,7 +123,7 @@
   yum_repository:
     name: elastic-{{ elastic.major_version }}
     file: elastic
-    description: Elastic Stack repository for {{ elastic.major_version }}.{{ elastic.suffix }}
+    description: Elastic Stack repository for {{ elastic.major_version }}.x
     baseurl: "{{ elastic_baseurl }}"
     gpgkey: "{{ elastic_gpgurl }}"
     gpgcheck: false

--- a/roles/elasticsearch/tasks/before.yml
+++ b/roles/elasticsearch/tasks/before.yml
@@ -4,7 +4,7 @@
   yum:
     name:
       - java-11-openjdk-headless
-      - elasticsearch
+      - 'elasticsearch-{{ elastic_version }}'
     state: installed
   register: es_install
 

--- a/roles/filebeat/tasks/main.yml
+++ b/roles/filebeat/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install filebeat package
   yum:
-    name: filebeat
+    name: 'filebeat-{{ elastic_version }}'
     state: present
 
 - name: Create filebeat config directory

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install packages
   yum:
-    name: kibana
+    name: 'kibana-{{ elastic_version }}'
     state: present
 
 - name: Update kibana config

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -4,7 +4,7 @@
   yum:
     name:
       - java-11-openjdk-headless
-      - logstash
+      - 'logstash-{{ elastic_version }}'
     state: present
 
 - name: Add sysconfig file


### PR DESCRIPTION
Previous logic did not allow for user to install a specific version of elastic.  Updated per #497 