### PR TITLE
ensure certificate gen and config file use the same template variable

### DIFF
--- a/roles/stenographer/templates/stenographer-config.j2
+++ b/roles/stenographer/templates/stenographer-config.j2
@@ -10,7 +10,7 @@
   , "StenotypePath": "/usr/bin/stenotype"
   , "Interface": "{{ item.1 }}"
   , "Port": {{ 1234 + item.0 }}
-  , "Host": "{{ ansible_default_ipv4.address }}"
+  , "Host": "{{ stenographer_monitor_interfaces[0] }}"
   , "Flags": ["-v"]
   , "CertPath": "/etc/stenographer/certs"
 }


### PR DESCRIPTION
when doing a single node install, it will generate the machine ip for the cert but the config file will say localhost. 