### PR TITLE
TASK [common : Configure firewall ports] fails during deploy

### DIFF
--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -285,13 +285,14 @@
 
 - name: Configure firewall ports
   firewalld:
-    port: "{{ item[1] }}"
+    port: "{{ item }}"
     zone: work
     permanent: true
     state: enabled
     immediate: true
-  loop: "{{ rock_mgmt_nets | product(['22/tcp']) | list }}"
-
+    loop:
+      - 22/tcp
+      
 - name: Ensure cache directory exists
   file:
     dest: "{{ rock_cache_dir }}"

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -283,6 +283,15 @@
   tags:
     - skip_ansible_lint  # [503] Tasks that run when changed should be handlers
 
+- name: Configure sources for work zone
+  firewalld:
+    source: "{{ item }}"
+    zone: work
+    permanent: true
+    immediate: true
+    state: enabled
+  loop: "{{ rock_mgmt_nets }}"
+
 - name: Configure firewall ports
   firewalld:
     port: "{{ item }}"
@@ -292,7 +301,7 @@
     immediate: true
   loop:
     - 22/tcp
-      
+
 - name: Ensure cache directory exists
   file:
     dest: "{{ rock_cache_dir }}"

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -290,8 +290,8 @@
     permanent: true
     state: enabled
     immediate: true
-    loop:
-      - 22/tcp
+  loop:
+    - 22/tcp
       
 - name: Ensure cache directory exists
   file:

--- a/roles/common/tasks/configure.yml
+++ b/roles/common/tasks/configure.yml
@@ -286,7 +286,6 @@
 - name: Configure firewall ports
   firewalld:
     port: "{{ item[1] }}"
-    source: "{{ item[0] }}"
     zone: work
     permanent: true
     state: enabled


### PR DESCRIPTION
Single and Multinode, Automated and custom Install

Output from Ansible:

`failed: [test.bench.lan] (item=[u'0.0.0.0/0', '22/tcp']) => {"ansible_loop_var": "item", "changed": false, "item": ["0.0.0.0/0", "22/tcp"], "msg": "can only operate on port, service, rich_rule, masquerade, icmp_block, icmp_block_inversion, interface or source at once"}`

Removed because the Ansible module for firewalld was updated and does not allow you to use both source and port in a single task