### PR TITLE
Fixes zookeeper in multinode configuration

### DIFF
--- a/molecule/multi-node/molecule.yml
+++ b/molecule/multi-node/molecule.yml
@@ -48,8 +48,31 @@ platforms:
       - stenographer
       - suricata
       - filebeat
-      - logstash
   - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-2"
+    memory: 16384
+    cpu: 4
+    disk_size: 64
+    guest_id: ${TEMPLATE_DISTRO-centos}7_64Guest
+    template_pattern: '^template-${TEMPLATE_DISTRO-centos}-7'
+    groups:
+      - rock
+      - zookeeper
+      - sensors
+      - zeek
+      - fsf
+      - kafka
+      - stenographer
+      - suricata
+      - filebeat
+  - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-3"
+    memory: 16384
+    cpu: 4
+    disk_size: 64
+    guest_id: ${TEMPLATE_DISTRO-centos}7_64Guest
+    template_pattern: '^template-${TEMPLATE_DISTRO-centos}-7'
+    groups:
+      - logstash
+  - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-4"
     memory: 16384
     cpu: 4
     disk_size: 64
@@ -64,7 +87,7 @@ platforms:
       - elasticsearch
       - docket
       - kibana
-  - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-3"
+  - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-5"
     memory: 16384
     cpu: 4
     disk_size: 64
@@ -75,7 +98,7 @@ platforms:
       - es_data
       - es_ingest
       - elasticsearch
-  - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-4"
+  - name: "rock-molecule-${MOLECULE_SCENARIO_NAME}${TOX_ENVNAME}-instance-6"
     memory: 16384
     cpu: 4
     disk_size: 64

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -150,10 +150,15 @@ fsf_data_dir: "{{ rock_data_dir }}/fsf"
 fsf_archive_dir: "{{ fsf_data_dir }}/archive"
 fsf_client_logfile: "{{ fsf_data_dir }}/client.log"
 fsf_retention: 3
+
 kafka_user: kafka
 kafka_group: kafka
 kafka_data_dir: "{{ rock_data_dir }}/kafka"
 kafka_config_path: /etc/kafka/server.properties
+kafka_zookeeper_host: "{{ hostvars[groups['zookeeper'][0]].ansible_default_ipv4.address }}"
+kafka_zookeeper_port: 2181
+kafka_zookeeper_chroot: ""
+
 es_user: elasticsearch
 es_group: elasticsearch
 es_data_dir: "{{ rock_data_dir }}/elasticsearch"

--- a/roles/elasticsearch/tasks/before.yml
+++ b/roles/elasticsearch/tasks/before.yml
@@ -171,5 +171,4 @@
   when: "(es_config.changed or es_memlock.changed or es_jvm.changed) and not es_install.changed"
   tags:
     - skip_ansible_lint  # [503] Tasks that run when changed should be handlers
-
 ...

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for kafka
 kafka_zookeeper_host: 127.0.0.1
 kafka_zookeeper_port: 2181
+kafka_zookeeper_chroot: ""

--- a/roles/kafka/files/wait-for-zookeeper.service
+++ b/roles/kafka/files/wait-for-zookeeper.service
@@ -5,6 +5,7 @@ Before=kafka.service
 After=network.target
 After=zookeeper.service
 Wants=zookeeper.service
+PartOf=kafka.service
 
 [Service]
 Type=notify

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -28,6 +28,18 @@
     regexp: "log.dirs="
     line: "log.dirs={{ kafka_data_dir }}"
 
+- name: Set kafka broker.id to automatic
+  lineinfile:
+    dest: "{{ kafka_config_path }}"
+    regexp: "broker.id="
+    line: "broker.id=-1"
+
+- name: Set kafka zookeeper.connect
+  lineinfile:
+    dest: "{{ kafka_config_path }}"
+    regexp: "zookeeper.connect="
+    line: "zookeeper.connect={{ kafka_zookeeper_host }}:{{ kafka_zookeeper_port }}{{ kafka_zookeeper_chroot }}"
+
 - name: Discover facts about data mount
   set_fact:
     rock_mounts:
@@ -153,6 +165,8 @@
     permanent: true
     state: enabled
     immediate: true
+    zone: work
   loop:
     - 9092
   when: groups['kafka'] | difference(groups['logstash']) | count > 0
+...

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -117,7 +117,7 @@
       mode: '0644'
   register: wait_for_zk_created
 
-- name: Create environment file for sidecar
+- name: Create environment file for zookeeper sidecar
   copy:
     dest: /etc/sysconfig/wait-for-zookeeper
     content: |

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -9,6 +9,17 @@
 - name: Enable and Start zookeeper
   systemd:
     name: zookeeper
-    enabled: "{{ local_services | selectattr('name', 'equalto', 'docket') | map(attribute='enabled') | first | bool }}"
+    enabled: "{{ local_services | selectattr('name', 'equalto', 'zookeeper') | map(attribute='enabled') | first | bool }}"
   notify: Restart zookeeper
+
+- name: Configure firewall ports
+  firewalld:
+    port: "{{ item }}/tcp"
+    permanent: true
+    state: enabled
+    immediate: true
+    zone: work
+  loop:
+    - 2181
+  when: groups['zookeeper'] | difference(groups['kafka']) | count > 0
 ...


### PR DESCRIPTION
Adds fixes for multi-node deployment when more than one kafka broker points to the same zookeeper. This does change a behavior for a scenario in which multiple sensors were independently deployed. To achieve that, the `kafka_zookeeper_host` variable should be overridden per "group" of sensor hosts that act as a single cluster. I do not suspect that this usecase is too widespread though.