### PR TITLE
Update es-jvm.options.j2

### DIFF
--- a/roles/elasticsearch/templates/es-jvm.options.j2
+++ b/roles/elasticsearch/templates/es-jvm.options.j2
@@ -32,9 +32,9 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+#-XX:+UseConcMarkSweepGC
+#-XX:CMSInitiatingOccupancyFraction=75
+#-XX:+UseCMSInitiatingOccupancyOnly
 
 ## G1GC Configuration
 # NOTE: G1GC is only supported on JDK version 10 or later.


### PR DESCRIPTION
Update jvm.options template to fix elasticsearch/java compatibility issues with their newest versions. 